### PR TITLE
Auto-connect to console after sandctl new

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Auto-generated from all feature plans. Last updated: 2026-01-22
 - Go 1.24 + Cobra (CLI framework), gopkg.in/yaml.v3 (config), golang.org/x/term (secure input) (010-rename-start-to-new)
 - Go 1.24 + github.com/spf13/cobra v1.9.1 (CLI), github.com/gorilla/websocket v1.5.1 (WebSocket), golang.org/x/term v0.30.0 (terminal control) (011-console-command)
 - ~/.sandctl/sessions.json (local session store), ~/.sandctl/config (YAML config) (011-console-command)
+- Go 1.24 + github.com/spf13/cobra v1.9.1 (CLI), golang.org/x/term v0.30.0 (terminal detection) (012-auto-console-after-new)
 
 - Go 1.22+ + Cobra (CLI framework), Viper (config), Fly.io Sprites SDK (001-sandbox-cli)
 
@@ -35,9 +36,9 @@ tests/
 Go 1.22+: Follow standard conventions
 
 ## Recent Changes
+- 012-auto-console-after-new: Added Go 1.24 + github.com/spf13/cobra v1.9.1 (CLI), golang.org/x/term v0.30.0 (terminal detection)
 - 011-console-command: Added Go 1.24 + github.com/spf13/cobra v1.9.1 (CLI), github.com/gorilla/websocket v1.5.1 (WebSocket), golang.org/x/term v0.30.0 (terminal control)
 - 010-rename-start-to-new: Added Go 1.24 + Cobra (CLI framework), gopkg.in/yaml.v3 (config), golang.org/x/term (secure input)
-- 008-e2e-test-suite: Added Go 1.23.0 + Cobra (CLI framework), `os/exec` (command execution), `testing` (Go standard test framework)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/012-auto-console-after-new/checklists/requirements.md
+++ b/specs/012-auto-console-after-new/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Auto Console After New
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Specification is ready for `/speckit.clarify` or `/speckit.plan`.
+- The feature builds on the existing console command (011-console-command), which provides the underlying infrastructure.
+- The `--no-console` flag ensures backward compatibility with existing automation workflows.

--- a/specs/012-auto-console-after-new/contracts/cli-interface.md
+++ b/specs/012-auto-console-after-new/contracts/cli-interface.md
@@ -1,0 +1,119 @@
+# CLI Interface Contract: sandctl new (Updated)
+
+**Version**: 2.0.0 (auto-console behavior)
+**Date**: 2026-01-25
+
+## Command Signature
+
+```
+sandctl new [flags]
+```
+
+## Flags
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| --timeout | -t | duration | "" | Auto-destroy after duration (e.g., 1h, 30m) |
+| --no-console | | bool | false | Skip automatic console connection after provisioning |
+
+## Behavior
+
+### Default Behavior (Interactive Terminal)
+
+When stdin is an interactive terminal and `--no-console` is not set:
+
+1. Provision VM with progress indicators
+2. Install development tools
+3. Install OpenCode
+4. Set up OpenCode authentication
+5. Display session name
+6. Automatically start interactive console session
+
+### Non-Interactive Behavior
+
+When stdin is NOT an interactive terminal OR `--no-console` is set:
+
+1. Provision VM with progress indicators
+2. Install development tools
+3. Install OpenCode
+4. Set up OpenCode authentication
+5. Display session name and usage hints
+6. Exit (no console session)
+
+## Output Format
+
+### Interactive Mode (Success)
+
+```
+Creating new session...
+✓ Provisioning VM
+✓ Installing development tools
+✓ Installing OpenCode
+✓ Setting up OpenCode authentication
+
+Session created: <session-name>
+Connecting to console...
+[interactive console session]
+```
+
+### Non-Interactive Mode / --no-console (Success)
+
+```
+Creating new session...
+✓ Provisioning VM
+✓ Installing development tools
+✓ Installing OpenCode
+✓ Setting up OpenCode authentication
+
+Session created: <session-name>
+
+Use 'sandctl console <session-name>' to connect.
+Use 'sandctl destroy <session-name>' when done.
+```
+
+### Console Connection Failure
+
+```
+Creating new session...
+✓ Provisioning VM
+✓ Installing development tools
+✓ Installing OpenCode
+✓ Setting up OpenCode authentication
+
+Session created: <session-name>
+Connecting to console...
+Error: Failed to connect to console: <error details>
+
+Session was created successfully. Use 'sandctl console <session-name>' to connect manually.
+```
+
+## Exit Codes
+
+| Code | Condition |
+|------|-----------|
+| 0 | Session created successfully (console optional) |
+| 1 | Provisioning failed or configuration error |
+
+Note: Console connection failure after successful provisioning returns exit code 0 because the primary operation succeeded.
+
+## Examples
+
+```bash
+# Create session and automatically connect (default)
+sandctl new
+
+# Create session with timeout, then connect
+sandctl new --timeout 2h
+
+# Create session without connecting (for scripts)
+sandctl new --no-console
+
+# Create session with timeout, no console (for automation)
+sandctl new --timeout 1h --no-console
+```
+
+## Backward Compatibility
+
+- Scripts using `sandctl new` without a TTY continue to work (auto-detect skips console)
+- Scripts can explicitly use `--no-console` to guarantee no console attempt
+- The --timeout flag behavior is unchanged

--- a/specs/012-auto-console-after-new/plan.md
+++ b/specs/012-auto-console-after-new/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: Auto Console After New
+
+**Branch**: `012-auto-console-after-new` | **Date**: 2026-01-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/012-auto-console-after-new/spec.md`
+
+## Summary
+
+Modify the `sandctl new` command to automatically start an interactive console session after provisioning completes. This reduces user friction by combining session creation and connection into a single command. The feature reuses the existing console infrastructure from feature 011-console-command, adding a `--no-console` flag for backward compatibility with scripts and automatic detection of non-interactive terminals.
+
+## Technical Context
+
+**Language/Version**: Go 1.24
+**Primary Dependencies**: github.com/spf13/cobra v1.9.1 (CLI), golang.org/x/term v0.30.0 (terminal detection)
+**Storage**: ~/.sandctl/sessions.json (local session store), ~/.sandctl/config (YAML config)
+**Testing**: Go testing package with build tags (e2e tag for E2E tests)
+**Target Platform**: macOS, Linux (CLI tool)
+**Project Type**: Single CLI application
+**Performance Goals**: Console connection adds no more than 3 seconds to provisioning time
+**Constraints**: Must restore terminal state on exit, must detect non-TTY stdin, backward compatible with existing scripts
+**Scale/Scope**: Single-user CLI tool connecting to one sprite at a time
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality | ✅ PASS | Modification to existing file, reuses console command functions |
+| II. Performance | ✅ PASS | Console connection time measurable, spec requires <3s overhead |
+| III. Security | ✅ PASS | No new credential handling; reuses existing auth flow |
+| IV. User Privacy | ✅ PASS | No data collection; terminal I/O only |
+| V. E2E Testing | ✅ PASS | Will verify existing tests still pass with --no-console behavior |
+
+**Quality Gates**:
+- Lint & Format: Will pass golangci-lint
+- Type Check: Go's static typing, no interface{} without justification
+- Unit Tests: Existing tests continue to work
+- E2E Tests: Existing new command tests work with --no-console flag
+- Performance: Console connection time measurable in E2E tests
+- Security Scan: No new dependencies
+- Code Review: Required before merge
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-auto-console-after-new/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── quickstart.md        # Phase 1 output
+└── contracts/           # Phase 1 output
+    └── cli-interface.md # CLI contract updates
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── cli/
+│   ├── root.go          # Shared helpers (getSpritesClient, getSessionStore)
+│   ├── console.go       # Existing console command (reused functions)
+│   └── new.go           # MODIFIED: Add auto-console after provisioning
+└── ...
+
+tests/
+└── e2e/
+    ├── cli_test.go      # E2E tests (modify to use --no-console where needed)
+    └── helpers.go       # Test helpers (reused)
+```
+
+**Structure Decision**: Single project structure. Modification to one existing file (`internal/cli/new.go`) plus test updates. Reuses console infrastructure from `internal/cli/console.go`.
+
+## Constitution Re-Check (Post Phase 1 Design)
+
+| Principle | Status | Verification |
+|-----------|--------|-----------------|
+| I. Code Quality | ✅ PASS | Single file modification, ~30 lines added, reuses existing functions |
+| II. Performance | ✅ PASS | Reuses proven console implementation, performance overhead minimal |
+| III. Security | ✅ PASS | No new attack surface, reuses existing auth flow |
+| IV. User Privacy | ✅ PASS | No data collection, terminal I/O only |
+| V. E2E Testing | ✅ PASS | CLI contract defined, testable via black-box approach |
+
+**All gates pass. Ready for task generation.**
+
+## Complexity Tracking
+
+No violations. Implementation is straightforward:
+- One existing CLI file modified (~30 lines added)
+- Reuses existing console session functions from console.go
+- No new dependencies required
+- Backward compatible via --no-console flag

--- a/specs/012-auto-console-after-new/quickstart.md
+++ b/specs/012-auto-console-after-new/quickstart.md
@@ -1,0 +1,120 @@
+# Quickstart: sandctl new (Auto-Console)
+
+This guide covers the updated `sandctl new` command which now automatically connects you to an interactive console after creating a session.
+
+## Basic Usage
+
+### Create and Connect (Default)
+
+Simply run `new` to create a session and immediately start working:
+
+```bash
+sandctl new
+```
+
+This will:
+1. Provision a new sandbox VM
+2. Install development tools
+3. Set up OpenCode
+4. Automatically connect you to an interactive terminal
+
+You'll see provisioning progress, then seamlessly transition to a shell prompt inside the sandbox.
+
+### Exit and Reconnect
+
+When you exit the console (Ctrl+D or `exit`), the sandbox keeps running:
+
+```bash
+# Reconnect to your session
+sandctl console alice
+```
+
+### Destroy When Done
+
+```bash
+sandctl destroy alice
+```
+
+## Advanced Usage
+
+### Skip Auto-Console
+
+For scripts or when you just want to create without connecting:
+
+```bash
+# Create session, don't connect
+sandctl new --no-console
+```
+
+### Create with Timeout
+
+Set an auto-destroy timer to avoid forgotten sessions:
+
+```bash
+# Auto-destroy after 2 hours
+sandctl new --timeout 2h
+
+# Combine with --no-console for automation
+sandctl new --timeout 1h --no-console
+```
+
+## In Scripts and CI
+
+The command automatically detects non-interactive environments:
+
+```bash
+#!/bin/bash
+# This automatically skips console (no TTY)
+SESSION=$(sandctl new 2>&1 | grep "Session created:" | awk '{print $3}')
+
+# Run commands
+sandctl exec "$SESSION" -c "npm install"
+sandctl exec "$SESSION" -c "npm test"
+
+# Cleanup
+sandctl destroy "$SESSION" --force
+```
+
+Or be explicit with `--no-console`:
+
+```bash
+#!/bin/bash
+sandctl new --no-console --timeout 30m
+```
+
+## Troubleshooting
+
+### Console Connection Failed
+
+If provisioning succeeds but console connection fails:
+
+```
+Session created: alice
+Error: Failed to connect to console: ...
+
+Session was created successfully. Use 'sandctl console alice' to connect manually.
+```
+
+The session is ready—just use `sandctl console` to connect.
+
+### "Console requires interactive terminal"
+
+This appears when running without a TTY:
+
+```
+Error: console requires an interactive terminal
+
+Use 'sandctl exec alice -c <command>' for non-interactive execution.
+```
+
+Use `--no-console` flag or `sandctl exec` for non-interactive use.
+
+## Summary
+
+| Scenario | Command |
+|----------|---------|
+| Create + connect | `sandctl new` |
+| Create only | `sandctl new --no-console` |
+| Create with timeout | `sandctl new --timeout 2h` |
+| Reconnect | `sandctl console <name>` |
+| Destroy | `sandctl destroy <name>` |

--- a/specs/012-auto-console-after-new/research.md
+++ b/specs/012-auto-console-after-new/research.md
@@ -1,0 +1,127 @@
+# Research: Auto Console After New
+
+**Feature**: 012-auto-console-after-new
+**Date**: 2026-01-25
+
+## Technical Decisions
+
+### 1. Reuse Console Infrastructure
+
+**Decision**: Call `runSpriteConsole()` from console.go directly rather than duplicating code.
+
+**Rationale**: The console command already implements:
+- Sprite CLI detection and fallback to WebSocket
+- Terminal state management (raw mode, restoration)
+- Signal handling (SIGINT, SIGTERM)
+- Auth failure detection and fallback
+
+**Alternatives Considered**:
+- Duplicate console logic in new.go: Rejected due to code duplication and maintenance burden
+- Create shared package: Overkill for this use case, functions can be shared within cli package
+
+### 2. Non-TTY Detection Strategy
+
+**Decision**: Check `term.IsTerminal(int(os.Stdin.Fd()))` before attempting console connection.
+
+**Rationale**:
+- Same pattern used by console command (proven approach)
+- Automatically handles CI, piped input, and script usage
+- No additional dependencies required
+
+**Alternatives Considered**:
+- Check only if --no-console flag is set: Rejected as it would break scripts that don't know about the new flag
+- Check if stdout is a terminal: Stdin is more reliable for interactive session detection
+
+### 3. Flag Name: --no-console
+
+**Decision**: Use `--no-console` as an opt-out flag rather than `--console` as an opt-in flag.
+
+**Rationale**:
+- Makes the new default behavior (auto-console) the expected experience
+- Existing scripts need to opt out, not opt in
+- Clearer intent: "I specifically don't want console"
+- Shorter common case (just `sandctl new`)
+
+**Alternatives Considered**:
+- `--console` (opt-in): Rejected because it makes the common interactive case require a flag
+- `--skip-console`: Rejected as less idiomatic than `--no-*` pattern
+
+### 4. Error Handling on Console Failure
+
+**Decision**: If console connection fails after successful provisioning, print error and session name, return nil (success).
+
+**Rationale**:
+- The primary operation (session creation) succeeded
+- Failing the command would be confusing since the session exists
+- User can retry connection with `sandctl console <name>`
+- Aligns with graceful degradation principle
+
+**Alternatives Considered**:
+- Return error: Rejected because session was created successfully
+- Silent failure: Rejected because user needs to know how to connect manually
+
+### 5. Message Sequencing
+
+**Decision**: Show "Session created: <name>" before starting console, with a brief message indicating console is starting.
+
+**Rationale**:
+- User needs to know session name for reconnection
+- Clear transition from provisioning to console phase
+- Aligns with FR-002 (session name must be displayed before console)
+
+**Message Sequence**:
+```
+✓ Provisioning VM
+✓ Installing development tools
+✓ Installing OpenCode
+✓ Setting up OpenCode authentication
+
+Session created: alice
+Connecting to console...
+[interactive session starts]
+```
+
+### 6. E2E Test Updates
+
+**Decision**: Update existing E2E tests to use `--no-console` flag to maintain test behavior.
+
+**Rationale**:
+- E2E tests run without TTY, so auto-console would be skipped anyway
+- Being explicit with `--no-console` makes test intent clear
+- Tests can verify both behaviors (with and without flag)
+
+## Implementation Notes
+
+### Functions to Reuse from console.go
+
+- `runSpriteConsole(sessionID string) error` - Main console entry point
+- No need to export these; they're in the same package
+
+### Changes to new.go
+
+1. Add `noConsole` flag variable
+2. Add flag registration in `init()`
+3. Add import for `golang.org/x/term`
+4. After provisioning success, check TTY and flag, then call `runSpriteConsole()`
+5. Handle console errors gracefully (print message, don't fail command)
+
+### Minimal Code Changes
+
+The implementation requires approximately:
+- 1 new flag variable
+- 1 new import
+- ~20 lines of logic after provisioning
+- Updates to help text
+
+## Dependencies
+
+- golang.org/x/term (already in go.mod from console command)
+- No new external dependencies
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Break existing scripts | Medium | High | --no-console flag for backward compatibility |
+| Console fails after provisioning | Low | Medium | Graceful error handling, show session name |
+| TTY detection incorrect | Low | Low | Use proven term.IsTerminal pattern |

--- a/specs/012-auto-console-after-new/spec.md
+++ b/specs/012-auto-console-after-new/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: Auto Console After New
+
+**Feature Branch**: `012-auto-console-after-new`
+**Created**: 2026-01-25
+**Status**: Draft
+**Input**: User description: "When I run `sandctl new`, it should create the sprite and install things as it currently does, then it should automatically start a console session, as if I ran `sandctl console <name>` immediately after it's done provisioning"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Seamless Session Creation and Connection (Priority: P1)
+
+As a developer, when I create a new sandbox session with `sandctl new`, I want to be automatically connected to an interactive terminal session immediately after provisioning completes, so I can start working without running a separate command.
+
+**Why this priority**: This is the core feature request. Currently users must run two commands (`sandctl new` followed by `sandctl console <name>`), which adds friction to the workflow. Automatic console connection removes this friction and provides a seamless experience.
+
+**Independent Test**: Run `sandctl new` in an interactive terminal and verify that after provisioning completes, the user is automatically placed in an interactive shell session inside the sandbox.
+
+**Acceptance Scenarios**:
+
+1. **Given** an interactive terminal with valid configuration, **When** user runs `sandctl new`, **Then** the system provisions the sandbox, installs tools, and automatically opens an interactive console session.
+
+2. **Given** a running `sandctl new` with auto-console, **When** user exits the console session (Ctrl+D or `exit`), **Then** the sandbox remains running and can be reconnected with `sandctl console <name>`.
+
+3. **Given** an interactive terminal, **When** user runs `sandctl new` and provisioning succeeds, **Then** the session name is displayed before console connection begins so the user knows what session they're connected to.
+
+---
+
+### User Story 2 - Skip Auto-Console Option (Priority: P2)
+
+As a developer running automated scripts or CI pipelines, I want the option to skip the automatic console connection, so I can create sessions programmatically without blocking on an interactive session.
+
+**Why this priority**: Supports automation use cases where the current behavior (create and exit) is preferred. Without this, users scripting with sandctl would lose functionality.
+
+**Independent Test**: Run `sandctl new --no-console` and verify that after provisioning, the command exits with the session name printed (current behavior) without starting a console.
+
+**Acceptance Scenarios**:
+
+1. **Given** a terminal, **When** user runs `sandctl new --no-console`, **Then** the session is created and the command exits after printing the session name (current behavior).
+
+2. **Given** a non-interactive environment (piped input), **When** user runs `sandctl new`, **Then** the system creates the session and exits without attempting console connection (auto-detects non-TTY).
+
+---
+
+### Edge Cases
+
+- What happens when console connection fails after successful provisioning?
+  - The session should remain created and usable. An error message should indicate the console connection failed and suggest running `sandctl console <name>` manually.
+
+- What happens when the user's terminal loses connection during the console session?
+  - Same as `sandctl console` behavior: the sandbox remains running and can be reconnected.
+
+- What happens when `sandctl new` is run in a non-interactive environment (CI, piped input)?
+  - The system should detect non-TTY stdin and behave as if `--no-console` was specified, avoiding blocking on console input.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: After successful provisioning, the `new` command MUST automatically initiate a console session using the same mechanism as `sandctl console <name>`.
+
+- **FR-002**: The session name MUST be displayed before the console connection begins so users know which session they are connected to.
+
+- **FR-003**: The `new` command MUST support a `--no-console` flag that skips automatic console connection and reverts to current behavior (print session name and exit).
+
+- **FR-004**: When stdin is not an interactive terminal, the `new` command MUST skip automatic console connection (equivalent to `--no-console`).
+
+- **FR-005**: If console connection fails after successful provisioning, the session MUST remain created and running. An error message MUST inform the user how to connect manually.
+
+- **FR-006**: When the user exits the console session, the sandbox MUST remain running (not be destroyed).
+
+- **FR-007**: The provisioning progress output (spinner, step messages) MUST complete and be visible before console connection starts.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can create and connect to a new session with a single command (`sandctl new`), reducing the required commands from 2 to 1.
+
+- **SC-002**: Time from running `sandctl new` to having an interactive shell is no longer than provisioning time plus 3 seconds for console connection.
+
+- **SC-003**: 100% of non-interactive invocations (non-TTY stdin) complete without blocking, maintaining compatibility with scripts and automation.
+
+- **SC-004**: Existing workflows using `sandctl new` in scripts continue to work when using the `--no-console` flag.
+
+## Assumptions
+
+- The `sandctl console` command infrastructure is already implemented and working (completed in feature 011-console-command).
+- Terminal detection uses the same mechanism as the existing console command (`term.IsTerminal`).
+- The sprite CLI wrapping and WebSocket fallback behaviors from console command apply here as well.

--- a/specs/012-auto-console-after-new/tasks.md
+++ b/specs/012-auto-console-after-new/tasks.md
@@ -1,0 +1,162 @@
+# Tasks: Auto Console After New
+
+**Input**: Design documents from `/specs/012-auto-console-after-new/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, contracts/cli-interface.md
+
+**Tests**: E2E tests updated per constitution principle V (E2E Testing Philosophy). Existing tests must continue to pass.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single project**: Go CLI application
+- **Source**: `internal/cli/`
+- **Tests**: `tests/e2e/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Add the --no-console flag infrastructure
+
+- [x] T001 Add `noConsole` flag variable to internal/cli/new.go
+- [x] T002 Register --no-console flag in init() function in internal/cli/new.go
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before user story implementation
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T003 Add golang.org/x/term import to internal/cli/new.go
+- [x] T004 Verify runSpriteConsole() is accessible from new.go (same package, no changes needed)
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Seamless Session Creation and Connection (Priority: P1) 🎯 MVP
+
+**Goal**: After provisioning, automatically start an interactive console session
+
+**Independent Test**: Run `sandctl new` in an interactive terminal and verify automatic console connection after provisioning completes
+
+### Implementation for User Story 1
+
+- [x] T005 [US1] Add TTY detection check using term.IsTerminal() in internal/cli/new.go runNew()
+- [x] T006 [US1] Add console connection logic after successful provisioning in internal/cli/new.go
+- [x] T007 [US1] Update success message to show "Connecting to console..." before runSpriteConsole() in internal/cli/new.go
+- [x] T008 [US1] Implement graceful error handling if console connection fails in internal/cli/new.go
+
+**Checkpoint**: User Story 1 complete - auto-console works for interactive terminals
+
+---
+
+## Phase 4: User Story 2 - Skip Auto-Console Option (Priority: P2)
+
+**Goal**: Provide --no-console flag and non-TTY detection for backward compatibility
+
+**Independent Test**: Run `sandctl new --no-console` and verify command exits after session creation without starting console
+
+### Implementation for User Story 2
+
+- [x] T009 [US2] Implement --no-console flag check to skip console in internal/cli/new.go
+- [x] T010 [US2] Ensure non-TTY detection works correctly (skip console when stdin is not terminal) in internal/cli/new.go
+- [x] T011 [US2] Update command help text to document --no-console flag in internal/cli/new.go
+
+**Checkpoint**: User Story 2 complete - backward compatibility maintained
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and E2E test updates
+
+- [x] T012 Update E2E tests to use --no-console flag where needed in tests/e2e/cli_test.go
+- [x] T013 Run golangci-lint on internal/cli/new.go
+- [ ] T014 [P] Manual test: Run `sandctl new` interactively, verify auto-console
+- [ ] T015 [P] Manual test: Run `sandctl new --no-console`, verify no console attempt
+- [ ] T016 Run full E2E test suite with `go test -v -tags=e2e ./tests/e2e/...`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-4)**: All depend on Foundational phase completion
+  - User stories proceed sequentially in priority order (P1 → P2)
+- **Polish (Phase 5)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - No dependencies on other stories
+- **User Story 2 (P2)**: Can start after US1 - Adds opt-out mechanism
+
+### Within Each User Story
+
+- Core implementation before refinements
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- T001 and T002 are sequential (same file, flag setup)
+- T003 and T004 can run in parallel (different concerns)
+- T014 and T015 can run in parallel (different test scenarios)
+
+---
+
+## Parallel Example: Phase 5 (Polish)
+
+```bash
+# These can run in parallel:
+Task: "Manual test: Run sandctl new interactively"
+Task: "Manual test: Run sandctl new --no-console"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: Foundational (T003-T004)
+3. Complete Phase 3: User Story 1 (T005-T008)
+4. **STOP and VALIDATE**: Test auto-console in interactive terminal
+5. Deploy/demo if ready - basic auto-console works
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → **MVP Complete**
+3. Add User Story 2 → Test independently → Backward compatibility complete
+4. Polish → Production ready
+
+### Single Developer Strategy
+
+This is a small feature (~30 lines of code added) suitable for a single developer:
+
+1. Complete all phases sequentially
+2. Estimated: Single focused session of work
+3. All code changes in one file (internal/cli/new.go) plus minor test updates
+
+---
+
+## Notes
+
+- All implementation is in existing file: `internal/cli/new.go`
+- Reuses `runSpriteConsole()` from `internal/cli/console.go` (same package)
+- E2E tests in `tests/e2e/cli_test.go` need --no-console flag for existing tests
+- No new dependencies required (golang.org/x/term already in go.mod)
+- Pattern follows existing console command closely

--- a/tests/e2e/cli_test.go
+++ b/tests/e2e/cli_test.go
@@ -173,7 +173,8 @@ func testNewSucceeds(t *testing.T) {
 	configPath := newTempConfig(t, token, openCodeKey)
 
 	t.Log("creating new session")
-	stdout, stderr, exitCode := runSandctlWithConfig(t, configPath, "new")
+	// Use --no-console to skip auto-console (tests run without TTY)
+	stdout, stderr, exitCode := runSandctlWithConfig(t, configPath, "new", "--no-console")
 
 	if exitCode != 0 {
 		t.Fatalf("new failed with exit code %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
@@ -207,9 +208,9 @@ func testExecRunsCommand(t *testing.T) {
 	openCodeKey := requireOpenCodeKey(t)
 	configPath := newTempConfig(t, token, openCodeKey)
 
-	// Create a session first
+	// Create a session first (use --no-console since tests run without TTY)
 	t.Log("creating session for exec test")
-	stdout, stderr, exitCode := runSandctlWithConfig(t, configPath, "new")
+	stdout, stderr, exitCode := runSandctlWithConfig(t, configPath, "new", "--no-console")
 	if exitCode != 0 {
 		t.Fatalf("could not create session for exec test: %s%s", stdout, stderr)
 	}
@@ -240,9 +241,9 @@ func testDestroyRemovesSession(t *testing.T) {
 	openCodeKey := requireOpenCodeKey(t)
 	configPath := newTempConfig(t, token, openCodeKey)
 
-	// Create a session first
+	// Create a session first (use --no-console since tests run without TTY)
 	t.Log("creating session for destroy test")
-	stdout, stderr, exitCode := runSandctlWithConfig(t, configPath, "new")
+	stdout, stderr, exitCode := runSandctlWithConfig(t, configPath, "new", "--no-console")
 	if exitCode != 0 {
 		t.Fatalf("could not create session for destroy test: %s%s", stdout, stderr)
 	}
@@ -291,9 +292,9 @@ func testWorkflowLifecycle(t *testing.T) {
 		t.Fatalf("workflow init failed: exit %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
 	}
 
-	// Step 2: New
+	// Step 2: New (use --no-console since tests run without TTY)
 	t.Log("workflow step 2: new")
-	stdout, stderr, exitCode = runSandctlWithConfig(t, configPath, "new")
+	stdout, stderr, exitCode = runSandctlWithConfig(t, configPath, "new", "--no-console")
 	if exitCode != 0 {
 		t.Fatalf("workflow new failed: exit %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
 	}


### PR DESCRIPTION
## Summary

- After `sandctl new` completes provisioning, automatically start an interactive console session
- Add `--no-console` flag to skip automatic console connection (for scripts and CI)
- Automatically detect non-TTY environments and skip console (backward compatible)
- Update E2E tests to use `--no-console` flag
- Add feature specification and implementation plan documents

## Test plan

- [ ] Run `sandctl new` interactively and verify automatic console connection
- [ ] Run `sandctl new --no-console` and verify it exits after session creation
- [ ] Verify E2E tests pass with `--no-console` flag