### PR TITLE
Sync sandctl-ts list with provider VMs

### DIFF
--- a/sandctl-ts/src/commands/list.ts
+++ b/sandctl-ts/src/commands/list.ts
@@ -1,7 +1,15 @@
 import { Command } from "commander";
 import { DateTime } from "luxon";
 
-import { getProvider, VMNotFoundError, type VMStatus } from "@/provider";
+import {
+	type Config,
+	getProviderConfig,
+	load,
+	type ProviderConfig,
+} from "@/config/config";
+import type { VMStatus } from "@/provider";
+import { get as getProviderFromRegistry } from "@/provider/registry";
+import type { VM } from "@/provider/types";
 import { SessionStore } from "@/session/store";
 import { type Session, type Status, timeoutRemaining } from "@/session/types";
 
@@ -63,80 +71,123 @@ function outputTable(sessions: Session[]): void {
 	}
 }
 
+interface Dependencies {
+	loadConfig: (configPath?: string) => Promise<Config>;
+	resolveProvider: (
+		name: string,
+		config: ProviderConfig,
+	) => ReturnType<typeof getProviderFromRegistry>;
+	warn: (message: string) => void;
+}
+
+const defaultDependencies: Dependencies = {
+	loadConfig: load,
+	resolveProvider: getProviderFromRegistry,
+	warn: (message: string) => {
+		console.warn(message);
+	},
+};
+
+async function syncProviderSessions(
+	sessions: Session[],
+	store: SessionStore,
+	deps: Dependencies,
+	configPath?: string,
+): Promise<void> {
+	const providerNames = [
+		...new Set(
+			sessions
+				.filter((session) => session.provider_id)
+				.map((session) => session.provider),
+		),
+	];
+
+	if (providerNames.length === 0) {
+		return;
+	}
+
+	let config: Config;
+	try {
+		config = await deps.loadConfig(configPath);
+	} catch (error) {
+		deps.warn(`Failed to load config for provider sync: ${String(error)}`);
+		return;
+	}
+
+	for (const providerName of providerNames) {
+		const providerConfig = getProviderConfig(config, providerName);
+		if (!providerConfig) {
+			deps.warn(
+				`[warn] Failed to sync provider '${providerName}': provider is not configured`,
+			);
+			continue;
+		}
+
+		const providerSessions = sessions.filter(
+			(session) => session.provider === providerName && session.provider_id,
+		);
+
+		let providerVMs: VM[];
+		try {
+			const provider = deps.resolveProvider(providerName, providerConfig);
+			providerVMs = await provider.list();
+		} catch (error) {
+			deps.warn(
+				`[warn] Failed to sync provider '${providerName}': ${String(error)}`,
+			);
+			continue;
+		}
+
+		const vmByID = new Map(providerVMs.map((vm) => [vm.id, vm]));
+
+		for (const session of providerSessions) {
+			const vm = vmByID.get(session.provider_id);
+			if (!vm) {
+				if (session.status === "running" || session.status === "provisioning") {
+					session.status = "stopped";
+					await store.update(session.id, { status: "stopped" });
+				}
+				continue;
+			}
+
+			const nextStatus = mapVMStatusToSession(vm.status);
+			const nextIP = vm.ipAddress ?? session.ip_address;
+			if (nextStatus !== session.status || nextIP !== session.ip_address) {
+				session.status = nextStatus;
+				session.ip_address = nextIP;
+				await store.update(session.id, {
+					status: session.status,
+					ip_address: session.ip_address,
+				});
+			}
+		}
+	}
+}
+
 export async function runList(
 	options: { format: string; all: boolean },
 	store = new SessionStore(),
+	deps: Partial<Dependencies> = {},
+	configPath?: string,
 ): Promise<void> {
+	const dependencies = {
+		...defaultDependencies,
+		...deps,
+	};
+
 	let sessions = (
 		options.all ? await store.list() : await store.listActive()
 	).map((session) => ({ ...session }));
 
-	const updatedSessions: Session[] = [];
 	for (const session of sessions) {
-		const updatedSession: Session = { ...session };
-
-		if (!updatedSession.provider_id) {
-			if (updatedSession.status !== "stopped") {
-				updatedSession.status = "stopped";
-				await store.update(updatedSession.id, { status: "stopped" });
-			}
-			updatedSessions.push(updatedSession);
-			continue;
+		if (!session.provider_id && session.status !== "stopped") {
+			session.status = "stopped";
+			await store.update(session.id, { status: "stopped" });
 		}
-
-		let provider: ReturnType<typeof getProvider>;
-		try {
-			provider = getProvider(updatedSession.provider);
-		} catch (error) {
-			console.warn(
-				`[warn] Failed to sync session '${updatedSession.id}': ${error}`,
-			);
-			updatedSessions.push(updatedSession);
-			continue;
-		}
-
-		if (!provider) {
-			updatedSessions.push(updatedSession);
-			continue;
-		}
-
-		try {
-			const vm = await provider.getVM(updatedSession.provider_id);
-			const nextStatus = mapVMStatusToSession(vm.status);
-			if (
-				nextStatus !== updatedSession.status ||
-				(vm.ip_address && vm.ip_address !== updatedSession.ip_address)
-			) {
-				updatedSession.status = nextStatus;
-				if (vm.ip_address) {
-					updatedSession.ip_address = vm.ip_address;
-				}
-				await store.update(updatedSession.id, {
-					status: updatedSession.status,
-					ip_address: updatedSession.ip_address,
-				});
-			}
-		} catch (error) {
-			if (error instanceof VMNotFoundError) {
-				if (
-					updatedSession.status === "running" ||
-					updatedSession.status === "provisioning"
-				) {
-					updatedSession.status = "stopped";
-					await store.update(updatedSession.id, { status: "stopped" });
-				}
-				updatedSessions.push(updatedSession);
-				continue;
-			}
-			console.warn(
-				`[warn] Failed to sync session '${updatedSession.id}': ${error}`,
-			);
-		}
-
-		updatedSessions.push(updatedSession);
 	}
 
-	sessions = updatedSessions;
+	await syncProviderSessions(sessions, store, dependencies, configPath);
+
 	if (!options.all) {
 		sessions = sessions.filter(
 			(session) =>
@@ -175,7 +226,8 @@ export function registerListCommand(): Command {
 			"table",
 		)
 		.option("-a, --all", "Include stopped and failed sessions", false)
-		.action(async (options: { format: string; all: boolean }) => {
-			await runList(options);
+		.action(async (options: { format: string; all: boolean }, command) => {
+			const globals = command.optsWithGlobals() as { config?: string };
+			await runList(options, undefined, undefined, globals.config);
 		});
 }

--- a/sandctl-ts/tests/unit/commands/list.test.ts
+++ b/sandctl-ts/tests/unit/commands/list.test.ts
@@ -4,10 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { formatTimeout, runList } from "@/commands/list";
-import * as providerModule from "@/provider";
-import { clearProviders, registerProvider, VMNotFoundError } from "@/provider";
+import type { Provider, SSHKeyManager } from "@/provider/interface";
+import type { VM } from "@/provider/types";
 import { SessionStore } from "@/session/store";
 import type { Session } from "@/session/types";
+import { baseProviderConfig } from "../../support/fixtures";
 
 describe("commands/list", () => {
 	let store: SessionStore;
@@ -29,14 +30,32 @@ describe("commands/list", () => {
 		store = new SessionStore(join(dir, "sessions.json"));
 		logSpy = spyOn(console, "log").mockImplementation(() => {});
 		warnSpy = spyOn(console, "warn").mockImplementation(() => {});
-		clearProviders();
 	});
 
 	afterEach(() => {
 		logSpy.mockRestore();
 		warnSpy.mockRestore();
-		clearProviders();
 	});
+
+	function makeProvider(vms: VM[]): Provider & SSHKeyManager {
+		return {
+			name: () => "hetzner",
+			create: async () => {
+				throw new Error("not implemented");
+			},
+			get: async () => {
+				throw new Error("not implemented");
+			},
+			delete: async () => {
+				throw new Error("not implemented");
+			},
+			list: async () => vms,
+			waitReady: async () => {
+				throw new Error("not implemented");
+			},
+			ensureSSHKey: async () => "1",
+		};
+	}
 
 	test("json format prints empty array when no active sessions", async () => {
 		await runList({ format: "json", all: false }, store);
@@ -69,43 +88,52 @@ describe("commands/list", () => {
 
 	test("provider sync updates session status", async () => {
 		await store.add(runningSession);
-		registerProvider("hetzner", {
-			async getVM() {
-				return { id: "123", status: "failed" };
-			},
-			async deleteVM() {},
+		await runList({ format: "table", all: true }, store, {
+			loadConfig: async () => baseProviderConfig,
+			resolveProvider: () =>
+				makeProvider([
+					{
+						id: "123",
+						name: "alice",
+						status: "failed",
+						ipAddress: "1.2.3.4",
+						region: "ash",
+						serverType: "cpx31",
+						createdAt: "2026-02-20T00:00:00Z",
+					},
+				]),
 		});
-		await runList({ format: "table", all: true }, store);
 		expect((await store.get("alice")).status).toBe("failed");
 	});
 
 	test("unknown providers are handled without failing", async () => {
 		await store.add({ ...runningSession, provider: "unknown" });
-		await runList({ format: "table", all: true }, store);
+		await runList({ format: "table", all: true }, store, {
+			loadConfig: async () => baseProviderConfig,
+		});
 		expect((await store.get("alice")).status).toBe("running");
+		expect(warnSpy).toHaveBeenCalled();
 	});
 
-	test("vm not found marks active session as stopped", async () => {
+	test("missing vm in provider list marks active session as stopped", async () => {
 		await store.add(runningSession);
-		registerProvider("hetzner", {
-			async getVM() {
-				throw new VMNotFoundError("123");
-			},
-			async deleteVM() {},
+		await runList({ format: "table", all: true }, store, {
+			loadConfig: async () => baseProviderConfig,
+			resolveProvider: () => makeProvider([]),
 		});
-		await runList({ format: "table", all: true }, store);
 		expect((await store.get("alice")).status).toBe("stopped");
 	});
 
 	test("provider sync failures are warnings and listing still succeeds", async () => {
 		await store.add(runningSession);
-		registerProvider("hetzner", {
-			async getVM() {
-				throw new Error("sync unavailable");
-			},
-			async deleteVM() {},
+		const provider = makeProvider([]);
+		provider.list = async () => {
+			throw new Error("sync unavailable");
+		};
+		await runList({ format: "table", all: true }, store, {
+			loadConfig: async () => baseProviderConfig,
+			resolveProvider: () => provider,
 		});
-		await runList({ format: "table", all: true }, store);
 		expect(warnSpy).toHaveBeenCalled();
 		expect(await store.get("alice")).toMatchObject({
 			id: "alice",
@@ -115,18 +143,14 @@ describe("commands/list", () => {
 		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("alice"));
 	});
 
-	test("provider lookup failures fall back to local session data", async () => {
+	test("provider resolution failures fall back to local session data", async () => {
 		await store.add(runningSession);
-		const providerSpy = spyOn(providerModule, "getProvider").mockImplementation(
-			() => {
+		await runList({ format: "table", all: true }, store, {
+			loadConfig: async () => baseProviderConfig,
+			resolveProvider: () => {
 				throw new Error("registry unavailable");
 			},
-		);
-		try {
-			await runList({ format: "table", all: true }, store);
-		} finally {
-			providerSpy.mockRestore();
-		}
+		});
 		expect(warnSpy).toHaveBeenCalled();
 		expect(await store.get("alice")).toMatchObject({
 			id: "alice",
@@ -134,6 +158,67 @@ describe("commands/list", () => {
 			provider_id: "123",
 		});
 		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("alice"));
+	});
+
+	test("sync calls provider list once for multiple sessions", async () => {
+		await store.add(runningSession);
+		await store.add({
+			...runningSession,
+			id: "bob",
+			provider_id: "456",
+			ip_address: "5.6.7.8",
+		});
+		let listCalls = 0;
+		const provider = makeProvider([
+			{
+				id: "123",
+				name: "alice",
+				status: "running",
+				ipAddress: "1.2.3.4",
+				region: "ash",
+				serverType: "cpx31",
+				createdAt: "2026-02-20T00:00:00Z",
+			},
+			{
+				id: "456",
+				name: "bob",
+				status: "running",
+				ipAddress: "5.6.7.8",
+				region: "ash",
+				serverType: "cpx31",
+				createdAt: "2026-02-20T00:00:00Z",
+			},
+		]);
+		provider.list = async () => {
+			listCalls += 1;
+			return await Promise.resolve([
+				{
+					id: "123",
+					name: "alice",
+					status: "running",
+					ipAddress: "1.2.3.4",
+					region: "ash",
+					serverType: "cpx31",
+					createdAt: "2026-02-20T00:00:00Z",
+				},
+				{
+					id: "456",
+					name: "bob",
+					status: "running",
+					ipAddress: "5.6.7.8",
+					region: "ash",
+					serverType: "cpx31",
+					createdAt: "2026-02-20T00:00:00Z",
+				},
+			]);
+		};
+
+		await runList({ format: "table", all: true }, store, {
+			loadConfig: async () => baseProviderConfig,
+			resolveProvider: () => provider,
+		});
+
+		expect(listCalls).toBe(1);
 	});
 
 	test("formatTimeout handles nil, expired, hours, and minutes", () => {


### PR DESCRIPTION
## Summary
- switch `sandctl-ts list` to provider-level reconciliation by loading configured providers and calling `provider.list()` once per provider
- update local sessions from provider VM state and IP, and mark active sessions stopped when their VM is missing remotely
- preserve graceful fallback behavior (warning + local output) when config/provider resolution/sync fails
- add unit tests for status reconciliation, missing remote VM handling, provider resolution failures, and single-call sync efficiency

## Testing
- `npx biome check src/commands/list.ts tests/unit/commands/list.test.ts`
- unable to run `bun test tests/unit/commands/list.test.ts` in this environment (`bun: command not found`)