### PR TITLE
Stop rewriting sandctl-ts version source at build time

### DIFF
--- a/sandctl-ts/scripts/build-all.sh
+++ b/sandctl-ts/scripts/build-all.sh
@@ -1,7 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-bun build src/index.ts --compile --target=bun-darwin-arm64 --outfile sandctl-darwin-arm64
-bun build src/index.ts --compile --target=bun-darwin-x64 --outfile sandctl-darwin-x64
-bun build src/index.ts --compile --target=bun-linux-x64 --outfile sandctl-linux-x64
-bun build src/index.ts --compile --target=bun-linux-arm64 --outfile sandctl-linux-arm64
+VERSION="${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")}";
+COMMIT="${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")}";
+BUILD_TIME="${BUILD_TIME:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}";
+
+BUN_BIN="${BUN_BIN:-$(command -v bun || true)}"
+if [[ -z "$BUN_BIN" && -x "$HOME/.bun/bin/bun" ]]; then
+	BUN_BIN="$HOME/.bun/bin/bun"
+fi
+
+if [[ -z "$BUN_BIN" ]]; then
+	echo "bun executable not found; install bun or set BUN_BIN" >&2
+	exit 127
+fi
+
+build_target() {
+	local target="$1"
+	local outfile="$2"
+	"$BUN_BIN" build src/index.ts \
+		--compile \
+		--target="$target" \
+		--outfile "$outfile" \
+		--define __SANDCTL_VERSION__="\"$VERSION\"" \
+		--define __SANDCTL_COMMIT__="\"$COMMIT\"" \
+		--define __SANDCTL_BUILD_TIME__="\"$BUILD_TIME\""
+}
+
+build_target bun-darwin-arm64 sandctl-darwin-arm64
+build_target bun-darwin-x64 sandctl-darwin-x64
+build_target bun-linux-x64 sandctl-linux-x64
+build_target bun-linux-arm64 sandctl-linux-arm64

--- a/sandctl-ts/scripts/build.sh
+++ b/sandctl-ts/scripts/build.sh
@@ -15,5 +15,9 @@ if [[ -z "$BUN_BIN" ]]; then
 	exit 127
 fi
 
-printf 'export const VERSION = "%s";\nexport const COMMIT = "%s";\nexport const BUILD_TIME = "%s";\n' "$VERSION" "$COMMIT" "$BUILD_TIME" > src/version.ts
-"$BUN_BIN" build src/index.ts --compile --outfile sandctl
+"$BUN_BIN" build src/index.ts \
+	--compile \
+	--outfile sandctl \
+	--define __SANDCTL_VERSION__="\"$VERSION\"" \
+	--define __SANDCTL_COMMIT__="\"$COMMIT\"" \
+	--define __SANDCTL_BUILD_TIME__="\"$BUILD_TIME\""

--- a/sandctl-ts/src/version.ts
+++ b/sandctl-ts/src/version.ts
@@ -1,3 +1,14 @@
-export const VERSION = "0629848-dirty";
-export const COMMIT = "0629848";
-export const BUILD_TIME = "2026-02-23T05:54:14Z";
+declare const __SANDCTL_VERSION__: string | undefined;
+declare const __SANDCTL_COMMIT__: string | undefined;
+declare const __SANDCTL_BUILD_TIME__: string | undefined;
+
+export const VERSION =
+	typeof __SANDCTL_VERSION__ === "string" ? __SANDCTL_VERSION__ : "dev";
+
+export const COMMIT =
+	typeof __SANDCTL_COMMIT__ === "string" ? __SANDCTL_COMMIT__ : "unknown";
+
+export const BUILD_TIME =
+	typeof __SANDCTL_BUILD_TIME__ === "string"
+		? __SANDCTL_BUILD_TIME__
+		: "unknown";


### PR DESCRIPTION
## Summary
- stop generating `src/version.ts` during build and keep the source file static with safe fallback values
- inject version, commit, and build time through Bun `--define` flags in both `scripts/build.sh` and `scripts/build-all.sh`
- preserve existing version command behavior while eliminating recurring local `src/version.ts` dirty-state churn

## Testing
- `~/.bun/bin/bun run lint -- src/version.ts src/commands/version.ts`
- `BUN_BIN=\"$HOME/.bun/bin/bun\" ./scripts/build.sh`