### PR TITLE
Fix SSH default user to match Go CLI (root → agent)

### DIFF
--- a/sandctl-ts/src/commands/shared/session-runtime.ts
+++ b/sandctl-ts/src/commands/shared/session-runtime.ts
@@ -94,7 +94,7 @@ export function buildSSHOptions(
 	if (config.ssh_key_source === "agent") {
 		return {
 			host,
-			username: "root",
+			username: "agent",
 			useAgent: true,
 		};
 	}
@@ -110,7 +110,7 @@ export function buildSSHOptions(
 
 	return {
 		host,
-		username: "root",
+		username: "agent",
 		privateKeyPath,
 	};
 }

--- a/sandctl-ts/src/ssh/client.ts
+++ b/sandctl-ts/src/ssh/client.ts
@@ -4,7 +4,7 @@ import { Client } from "ssh2";
 import { discoverPrimaryAgentSocket } from "@/ssh/agent";
 
 const DEFAULT_PORT = 22;
-const DEFAULT_USERNAME = "root";
+const DEFAULT_USERNAME = "agent";
 const DEFAULT_TIMEOUT_MS = 10_000;
 
 export interface SSHClientOptions {

--- a/sandctl-ts/tests/unit/commands/session-runtime.test.ts
+++ b/sandctl-ts/tests/unit/commands/session-runtime.test.ts
@@ -97,7 +97,7 @@ describe("buildSSHOptions", () => {
 		const opts = buildSSHOptions(config, "10.0.0.1");
 		expect(opts).toEqual({
 			host: "10.0.0.1",
-			username: "root",
+			username: "agent",
 			useAgent: true,
 		} satisfies SSHClientOptions);
 	});
@@ -110,7 +110,7 @@ describe("buildSSHOptions", () => {
 		const opts = buildSSHOptions(config, "10.0.0.2");
 		expect(opts).toEqual({
 			host: "10.0.0.2",
-			username: "root",
+			username: "agent",
 			privateKeyPath: "/home/user/.ssh/id_ed25519.pub".slice(0, -4),
 		} satisfies SSHClientOptions);
 	});

--- a/sandctl-ts/tests/unit/ssh/client.test.ts
+++ b/sandctl-ts/tests/unit/ssh/client.test.ts
@@ -45,7 +45,7 @@ describe("ssh/client", () => {
 		expect(connectConfig).toMatchObject({
 			host: "192.0.2.10",
 			port: 22,
-			username: "root",
+			username: "agent",
 			agent: "/tmp/agent.sock",
 		});
 	});


### PR DESCRIPTION
## Summary

- The Go CLI connects to VMs as the `agent` user (created by cloud-init), but the TypeScript rewrite was defaulting to `root`
- Fixed `DEFAULT_USERNAME` in `src/ssh/client.ts` and hardcoded `username` in `src/commands/shared/session-runtime.ts`
- Updated corresponding unit tests

## Test plan
- [x] All 182 unit tests pass
- [ ] Verify SSH connections work correctly with a live VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)