### PR TITLE
Fix session name normalization to trim whitespace

### DIFF
--- a/sandctl-ts/src/session/id.ts
+++ b/sandctl-ts/src/session/id.ts
@@ -9,5 +9,5 @@ export function validateID(id: string): boolean {
 }
 
 export function normalizeName(name: string): string {
-	return name.toLowerCase();
+	return name.trim().toLowerCase();
 }

--- a/sandctl-ts/tests/unit/session/id.test.ts
+++ b/sandctl-ts/tests/unit/session/id.test.ts
@@ -23,4 +23,9 @@ describe("session/id", () => {
 	test("normalizeName lowercases input", () => {
 		expect(normalizeName("AlIcE")).toBe("alice");
 	});
+
+	test("normalizeName trims whitespace", () => {
+		expect(normalizeName("  alice  ")).toBe("alice");
+		expect(normalizeName("\talice\n")).toBe("alice");
+	});
 });


### PR DESCRIPTION
## Summary

- Go CLI uses `strings.TrimSpace()` before `strings.ToLower()` when normalizing session names
- TS rewrite only lowercased, missing the trim step
- Added `.trim()` before `.toLowerCase()` to match Go behavior

## Test plan
- [x] Existing tests pass
- [x] New test case for whitespace trimming added

🤖 Generated with [Claude Code](https://claude.com/claude-code)