### PR TITLE
Use content-based hash for SSH key naming to match Go CLI

### DIFF
--- a/sandctl-ts/src/commands/new.ts
+++ b/sandctl-ts/src/commands/new.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { Command } from "commander";
 import { createSpinner } from "nanospinner";
 import {
@@ -143,6 +144,11 @@ function waitReadyTimeoutMs(options: NewOptions): number {
 	return Duration.parse(options.timeout).milliseconds;
 }
 
+export function sshKeyName(publicKey: string): string {
+	const hex = createHash("md5").update(publicKey).digest("hex");
+	return `sandctl-${hex.slice(0, 8)}`;
+}
+
 function shellQuote(value: string): string {
 	return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -213,7 +219,7 @@ export async function runNew(
 
 	const publicKey = await dependencies.getPublicKey(config);
 	const sshKeyID = await provider.ensureSSHKey(
-		`sandctl-${sessionID}`,
+		sshKeyName(publicKey),
 		publicKey,
 	);
 


### PR DESCRIPTION
## Summary

- Go CLI names SSH keys as `sandctl-{md5_hash_prefix}` based on public key content, enabling key reuse across sessions
- TS was using `sandctl-${sessionID}`, creating a new key name per session
- Changed to use MD5 hash of public key content (first 8 hex chars) to match Go convention

## Test plan
- [x] All 175 unit tests pass
- [ ] Verify SSH key reuse works correctly with real Hetzner account

🤖 Generated with [Claude Code](https://claude.com/claude-code)