### PR TITLE
fix(ts): increase SSH connection timeout to 30s

### DIFF
--- a/sandctl-ts/src/ssh/client.ts
+++ b/sandctl-ts/src/ssh/client.ts
@@ -5,7 +5,7 @@ import { discoverPrimaryAgentSocket } from "@/ssh/agent";
 
 const DEFAULT_PORT = 22;
 const DEFAULT_USERNAME = "agent";
-const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
 
 export interface SSHClientOptions {
 	host: string;


### PR DESCRIPTION
## Summary
• The Go CLI uses a 30-second SSH connection timeout (`defaultSSHTimeout = 30 * time.Second`), but the TypeScript rewrite was using 10 seconds
• This could cause spurious connection failures on slower networks or when the VM is still busy with cloud-init
• Changes `DEFAULT_TIMEOUT_MS` from `10_000` to `30_000` in `sandctl-ts/src/ssh/client.ts`

## Test plan
- [ ] Existing SSH client unit tests still pass
- [ ] E2E tests pass with the new timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)