### PR TITLE
feat: add global --json flag for machine-readable output

### DIFF
--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -37,13 +37,18 @@ const defaultDependencies: Dependencies = {
 	resolveLegacyProvider: getProvider,
 };
 
+export interface DestroyResult {
+	id: string;
+	destroyed: boolean;
+}
+
 export async function runDestroy(
 	name: string,
-	options: { force: boolean },
+	options: { force: boolean; silent?: boolean },
 	store = new SessionStore(),
 	deps: Partial<Dependencies> = {},
 	configPath?: string,
-): Promise<void> {
+): Promise<DestroyResult> {
 	const dependencies = {
 		...defaultDependencies,
 		...deps,
@@ -71,8 +76,10 @@ export async function runDestroy(
 			);
 		}
 		await store.remove(session.id);
-		console.log(`Session '${session.id}' destroyed.`);
-		return;
+		if (!options.silent) {
+			console.log(`Session '${session.id}' destroyed.`);
+		}
+		return { id: session.id, destroyed: true };
 	}
 
 	if (!options.force) {
@@ -81,8 +88,10 @@ export async function runDestroy(
 			default: false,
 		});
 		if (!accepted) {
-			console.log("Canceled.");
-			return;
+			if (!options.silent) {
+				console.log("Canceled.");
+			}
+			return { id: session.id, destroyed: false };
 		}
 	}
 
@@ -131,7 +140,10 @@ export async function runDestroy(
 	}
 
 	await store.remove(session.id);
-	console.log(`Session '${session.id}' destroyed.`);
+	if (!options.silent) {
+		console.log(`Session '${session.id}' destroyed.`);
+	}
+	return { id: session.id, destroyed: true };
 }
 
 export function registerDestroyCommand(): Command {
@@ -141,7 +153,22 @@ export function registerDestroyCommand(): Command {
 		.argument("<name>")
 		.option("-f, --force", "Skip confirmation prompt", false)
 		.action(async (name: string, options: { force: boolean }, command) => {
-			const globals = command.optsWithGlobals() as { config?: string };
-			await runDestroy(name, options, undefined, undefined, globals.config);
+			const globals = command.optsWithGlobals() as {
+				config?: string;
+				json?: boolean;
+			};
+			if (globals.json) {
+				options.force = true;
+			}
+			const result = await runDestroy(
+				name,
+				{ ...options, silent: globals.json },
+				undefined,
+				undefined,
+				globals.config,
+			);
+			if (globals.json) {
+				console.log(JSON.stringify(result, null, 2));
+			}
 		});
 }

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -104,7 +104,46 @@ export function registerExecCommand(): Command {
 				options: ExecOptions,
 				command: Command,
 			): Promise<void> => {
-				const globals = command.optsWithGlobals() as { config?: string };
+				const globals = command.optsWithGlobals() as {
+					config?: string;
+					json?: boolean;
+				};
+
+				if (globals.json && options.command) {
+					let stdoutBuf = "";
+					let stderrBuf = "";
+					const exitCode = await runExec(
+						name,
+						options,
+						{
+							stdout: {
+								write(chunk: string | Uint8Array) {
+									stdoutBuf += chunk.toString();
+									return true;
+								},
+							},
+							stderr: {
+								write(chunk: string | Uint8Array) {
+									stderrBuf += chunk.toString();
+									return true;
+								},
+							},
+						},
+						globals.config,
+					);
+					console.log(
+						JSON.stringify(
+							{ exit_code: exitCode, stdout: stdoutBuf, stderr: stderrBuf },
+							null,
+							2,
+						),
+					);
+					if (exitCode !== 0) {
+						process.exitCode = exitCode;
+					}
+					return;
+				}
+
 				const exitCode = await runExec(name, options, {}, globals.config);
 				if (exitCode !== 0) {
 					process.exitCode = exitCode;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -59,10 +59,15 @@ async function pathExists(targetPath: string): Promise<boolean> {
 	}
 }
 
+export interface InitResult {
+	config_path: string;
+	saved: boolean;
+}
+
 export async function runInit(
 	options: InitOptions,
 	configPath: string,
-): Promise<void> {
+): Promise<InitResult> {
 	const resolvedConfigPath = expandTilde(configPath);
 
 	if (options.sshAgent && options.sshPublicKey) {
@@ -114,9 +119,7 @@ export async function runInit(
 			);
 		}
 		await save(resolvedConfigPath, buildConfig(options));
-		console.log(`Configuration saved successfully to ${resolvedConfigPath}`);
-		console.log("Next step: sandctl new");
-		return;
+		return { config_path: resolvedConfigPath, saved: true };
 	}
 
 	if (!process.stdin.isTTY || !process.stdout.isTTY) {
@@ -232,8 +235,7 @@ export async function runInit(
 			githubToken,
 		}),
 	);
-	console.log(`Configuration saved successfully to ${resolvedConfigPath}`);
-	console.log("Next step: sandctl new");
+	return { config_path: resolvedConfigPath, saved: true };
 }
 
 function buildConfig(options: InitOptions): Config {
@@ -281,7 +283,32 @@ export function registerInitCommand(): Command {
 		.option("--git-user-email <email>", "Git user.email")
 		.option("--github-token <token>", "GitHub personal access token")
 		.action(async (options: InitOptions, command) => {
-			const globals = command.optsWithGlobals() as { config?: string };
-			await runInit(options, globals.config ?? "~/.sandctl/config");
+			const globals = command.optsWithGlobals() as {
+				config?: string;
+				json?: boolean;
+			};
+			if (globals.json) {
+				const hasNonInteractiveFlags =
+					Boolean(options.hetznerToken) ||
+					Boolean(options.sshAgent) ||
+					Boolean(options.sshPublicKey);
+				if (!hasNonInteractiveFlags) {
+					throw new Error(
+						"--json requires non-interactive flags (--hetzner-token with --ssh-agent or --ssh-public-key)",
+					);
+				}
+			}
+			const result = await runInit(
+				options,
+				globals.config ?? "~/.sandctl/config",
+			);
+			if (globals.json) {
+				console.log(JSON.stringify(result, null, 2));
+			} else {
+				console.log(
+					`Configuration saved successfully to ${result.config_path}`,
+				);
+				console.log("Next step: sandctl new");
+			}
 		});
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -227,7 +227,13 @@ export function registerListCommand(): Command {
 		)
 		.option("-a, --all", "Include stopped and failed sessions", false)
 		.action(async (options: { format: string; all: boolean }, command) => {
-			const globals = command.optsWithGlobals() as { config?: string };
+			const globals = command.optsWithGlobals() as {
+				config?: string;
+				json?: boolean;
+			};
+			if (globals.json) {
+				options.format = "json";
+			}
 			await runList(options, undefined, undefined, globals.config);
 		});
 }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -499,7 +499,21 @@ export function registerNewCommand(): Command {
 			"Skip automatic console connection after provisioning",
 		)
 		.action(async (options: NewOptions, command) => {
-			const globals = command.optsWithGlobals() as { config?: string };
+			const globals = command.optsWithGlobals() as {
+				config?: string;
+				json?: boolean;
+			};
+			if (globals.json) {
+				options.noConsole = true;
+				const noop = () => {};
+				const session = await runNewCommand(options, globals.config, {
+					createSpinner: () => ({ succeed: noop, fail: noop }),
+					log: noop,
+					warn: noop,
+				});
+				console.log(JSON.stringify(session, null, 2));
+				return;
+			}
 			await runNewCommand(options, globals.config);
 		});
 }

--- a/src/commands/template-add.ts
+++ b/src/commands/template-add.ts
@@ -18,6 +18,7 @@ const defaultDependencies: Dependencies = {
 
 export async function runTemplateAdd(
 	name: string,
+	options: { json?: boolean } = {},
 	store = new TemplateStore(),
 	deps: Partial<Dependencies> = {},
 ): Promise<void> {
@@ -38,6 +39,11 @@ export async function runTemplateAdd(
 			return;
 		}
 		throw error;
+	}
+
+	if (options.json) {
+		console.log(JSON.stringify(config, null, 2));
+		return;
 	}
 
 	const scriptPath = await store.getInitScriptPath(name);
@@ -63,7 +69,8 @@ export function registerTemplateAddCommand(): Command {
 	return new Command("add")
 		.description("Create a new template configuration")
 		.argument("<name>", "Template name")
-		.action(async (name: string) => {
-			await runTemplateAdd(name);
+		.action(async (name: string, _options: unknown, command: Command) => {
+			const globals = command.optsWithGlobals() as { json?: boolean };
+			await runTemplateAdd(name, { json: globals.json });
 		});
 }

--- a/src/commands/template-list.ts
+++ b/src/commands/template-list.ts
@@ -18,12 +18,18 @@ function formatCreatedAt(iso: string): string {
 }
 
 export async function runTemplateList(
+	options: { json?: boolean } = {},
 	store = new TemplateStore(),
 	deps: Partial<Dependencies> = {},
 ): Promise<void> {
 	const { log } = { ...defaultDependencies, ...deps };
 
 	const configs = await store.list();
+
+	if (options.json) {
+		console.log(JSON.stringify(configs, null, 2));
+		return;
+	}
 
 	if (configs.length === 0) {
 		log("No templates configured.");
@@ -46,7 +52,8 @@ export async function runTemplateList(
 export function registerTemplateListCommand(): Command {
 	return new Command("list")
 		.description("List all configured templates")
-		.action(async () => {
-			await runTemplateList();
+		.action(async (_options: unknown, command: Command) => {
+			const globals = command.optsWithGlobals() as { json?: boolean };
+			await runTemplateList({ json: globals.json });
 		});
 }

--- a/src/commands/template-remove.ts
+++ b/src/commands/template-remove.ts
@@ -15,13 +15,13 @@ const defaultDependencies: Dependencies = {
 
 export async function runTemplateRemove(
 	name: string,
-	options: { force: boolean },
+	options: { force: boolean; json?: boolean },
 	store = new TemplateStore(),
 	deps: Partial<Dependencies> = {},
 ): Promise<void> {
 	const { log, confirm: askConfirm } = { ...defaultDependencies, ...deps };
 
-	if (!options.force) {
+	if (!options.force && !options.json) {
 		const accepted = await askConfirm(`Delete template '${name}'?`);
 		if (!accepted) {
 			log("Canceled.");
@@ -40,6 +40,11 @@ export async function runTemplateRemove(
 		throw error;
 	}
 
+	if (options.json) {
+		console.log(JSON.stringify({ name, removed: true }, null, 2));
+		return;
+	}
+
 	log(`Template '${name}' deleted.`);
 }
 
@@ -48,7 +53,10 @@ export function registerTemplateRemoveCommand(): Command {
 		.description("Delete a template")
 		.argument("<name>", "Template name")
 		.option("-f, --force", "Skip confirmation prompt", false)
-		.action(async (name: string, options: { force: boolean }) => {
-			await runTemplateRemove(name, options);
-		});
+		.action(
+			async (name: string, options: { force: boolean }, command: Command) => {
+				const globals = command.optsWithGlobals() as { json?: boolean };
+				await runTemplateRemove(name, { ...options, json: globals.json });
+			},
+		);
 }

--- a/src/commands/template-show.ts
+++ b/src/commands/template-show.ts
@@ -12,6 +12,7 @@ const defaultDependencies: Dependencies = {
 
 export async function runTemplateShow(
 	name: string,
+	options: { json?: boolean } = {},
 	store = new TemplateStore(),
 	deps: Partial<Dependencies> = {},
 ): Promise<void> {
@@ -19,6 +20,16 @@ export async function runTemplateShow(
 
 	try {
 		const initScript = await store.getInitScript(name);
+		if (options.json) {
+			console.log(
+				JSON.stringify(
+					{ name: initScript.name, script: initScript.script },
+					null,
+					2,
+				),
+			);
+			return;
+		}
 		const content = initScript.script.endsWith("\n")
 			? initScript.script
 			: `${initScript.script}\n`;
@@ -37,7 +48,8 @@ export function registerTemplateShowCommand(): Command {
 	return new Command("show")
 		.description("Display a template's init script")
 		.argument("<name>", "Template name")
-		.action(async (name: string) => {
-			await runTemplateShow(name);
+		.action(async (name: string, _options: unknown, command: Command) => {
+			const globals = command.optsWithGlobals() as { json?: boolean };
+			await runTemplateShow(name, { json: globals.json });
 		});
 }

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -5,7 +5,18 @@ import { BUILD_TIME, COMMIT, VERSION } from "@/version";
 export function registerVersionCommand(): Command {
 	return new Command("version")
 		.description("Show version information")
-		.action(() => {
+		.action((_options, command) => {
+			const globals = command.optsWithGlobals() as { json?: boolean };
+			if (globals.json) {
+				console.log(
+					JSON.stringify(
+						{ version: VERSION, commit: COMMIT, build_time: BUILD_TIME },
+						null,
+						2,
+					),
+				);
+				return;
+			}
 			console.log(`sandctl version ${VERSION}`);
 			console.log(`  commit: ${COMMIT}`);
 			console.log(`  built:  ${BUILD_TIME}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ const program = new Command()
 	.name("sandctl")
 	.description("Manage sandboxed AI web development agents")
 	.option("--config <path>", "Config file path", "~/.sandctl/config")
-	.option("-v, --verbose", "Enable verbose debug output");
+	.option("-v, --verbose", "Enable verbose debug output")
+	.option("--json", "Output results as JSON");
 
 program.addCommand(registerVersionCommand());
 program.addCommand(registerInitCommand());

--- a/tests/unit/commands/destroy.test.ts
+++ b/tests/unit/commands/destroy.test.ts
@@ -133,4 +133,37 @@ describe("commands/destroy", () => {
 		expect(await store.get("alice")).toMatchObject({ id: "alice" });
 		expect(warnSpy).toHaveBeenCalled();
 	});
+
+	test("silent option suppresses console output", async () => {
+		await store.add(session);
+
+		const provider: Provider & SSHKeyManager = {
+			name: () => "hetzner",
+			create: async () => {
+				throw new Error("not implemented");
+			},
+			get: async () => {
+				throw new Error("not implemented");
+			},
+			delete: async () => {},
+			list: async () => [],
+			waitReady: async () => {
+				throw new Error("not implemented");
+			},
+			ensureSSHKey: async () => "1",
+		};
+
+		const result = await runDestroy(
+			"alice",
+			{ force: true, silent: true },
+			store,
+			{
+				loadConfig: async () => baseProviderConfig,
+				resolveProvider: () => provider,
+			},
+		);
+
+		expect(result).toEqual({ id: "alice", destroyed: true });
+		expect(logSpy).not.toHaveBeenCalled();
+	});
 });

--- a/tests/unit/commands/init.test.ts
+++ b/tests/unit/commands/init.test.ts
@@ -124,4 +124,26 @@ describe("init command (non-interactive)", () => {
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
 	});
+
+	test("returns result object with config path", async () => {
+		const tmpDir = mkdtempSync(path.join(os.tmpdir(), "sandctl-ts-init-"));
+		try {
+			const configPath = path.join(tmpDir, "config.yaml");
+
+			const result = await runInit(
+				{
+					hetznerToken: "token",
+					sshAgent: true,
+				},
+				configPath,
+			);
+
+			expect(result).toEqual({
+				config_path: configPath,
+				saved: true,
+			});
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/tests/unit/commands/template-add.test.ts
+++ b/tests/unit/commands/template-add.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -12,7 +12,7 @@ describe("template add", () => {
 		const output: string[] = [];
 		const openEditor = mock(async () => {});
 
-		await runTemplateAdd("Ghost", store, {
+		await runTemplateAdd("Ghost", {}, store, {
 			log: (msg: string) => output.push(msg),
 			errLog: (msg: string) => output.push(msg),
 			openEditor,
@@ -31,7 +31,7 @@ describe("template add", () => {
 		const errors: string[] = [];
 		const openEditor = mock(async () => {});
 
-		await runTemplateAdd("Ghost", store, {
+		await runTemplateAdd("Ghost", {}, store, {
 			log: () => {},
 			errLog: (msg: string) => errors.push(msg),
 			openEditor,
@@ -46,7 +46,7 @@ describe("template add", () => {
 		const store = new TemplateStore(root);
 
 		await expect(
-			runTemplateAdd("", store, {
+			runTemplateAdd("", {}, store, {
 				log: () => {},
 				errLog: () => {},
 				openEditor: async () => {},
@@ -62,7 +62,7 @@ describe("template add", () => {
 			throw new Error("editor crashed");
 		});
 
-		await runTemplateAdd("Ghost", store, {
+		await runTemplateAdd("Ghost", {}, store, {
 			log: (msg: string) => output.push(msg),
 			errLog: (msg: string) => output.push(msg),
 			openEditor,
@@ -70,5 +70,29 @@ describe("template add", () => {
 
 		expect(await store.exists("Ghost")).toBe(true);
 		expect(output.some((m) => m.includes("init.sh"))).toBe(true);
+	});
+
+	test("json option outputs template config and skips editor", async () => {
+		const root = await mkdtemp(join(tmpdir(), "sandctl-tpl-add-"));
+		const store = new TemplateStore(root);
+		const openEditor = mock(async () => {});
+
+		const logSpy = spyOn(console, "log").mockImplementation(() => {});
+		try {
+			await runTemplateAdd("Ghost", { json: true }, store, {
+				log: () => {},
+				errLog: () => {},
+				openEditor,
+			});
+
+			expect(openEditor).not.toHaveBeenCalled();
+			expect(logSpy).toHaveBeenCalledTimes(1);
+			const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
+			expect(parsed).toHaveProperty("template", "ghost");
+			expect(parsed).toHaveProperty("original_name", "Ghost");
+			expect(parsed).toHaveProperty("created_at");
+		} finally {
+			logSpy.mockRestore();
+		}
 	});
 });

--- a/tests/unit/commands/template-list.test.ts
+++ b/tests/unit/commands/template-list.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -14,7 +14,9 @@ describe("template list", () => {
 		await store.add("Alpha");
 
 		const output: string[] = [];
-		await runTemplateList(store, { log: (msg: string) => output.push(msg) });
+		await runTemplateList({}, store, {
+			log: (msg: string) => output.push(msg),
+		});
 
 		expect(output.some((m) => m.includes("NAME"))).toBe(true);
 		expect(output.some((m) => m.includes("Ghost"))).toBe(true);
@@ -26,7 +28,9 @@ describe("template list", () => {
 		const store = new TemplateStore(root);
 
 		const output: string[] = [];
-		await runTemplateList(store, { log: (msg: string) => output.push(msg) });
+		await runTemplateList({}, store, {
+			log: (msg: string) => output.push(msg),
+		});
 
 		expect(output.some((m) => m.includes("No templates configured"))).toBe(
 			true,
@@ -41,14 +45,16 @@ describe("template list", () => {
 		await store.add("Averylongnameexceedstwenty");
 
 		const output: string[] = [];
-		await runTemplateList(store, { log: (msg: string) => output.push(msg) });
+		await runTemplateList({}, store, {
+			log: (msg: string) => output.push(msg),
+		});
 
 		const dataRow = output.find((m) => m.includes("Averylongname"));
 		expect(dataRow).toBeTruthy();
 
 		// The name column is 20 chars wide; position 20 should be a space separator
 		// not a letter continuing the overflowing name.
-		const charAt20 = dataRow![20];
+		const charAt20 = (dataRow as string)[20];
 		expect(charAt20).toBe(" ");
 	});
 
@@ -70,12 +76,47 @@ describe("template list", () => {
 		const output: string[] = [];
 
 		// Should not throw; should show "invalid date" or fallback text
-		await runTemplateList(store, { log: (msg: string) => output.push(msg) });
+		await runTemplateList({}, store, {
+			log: (msg: string) => output.push(msg),
+		});
 
 		const row = output.find((m) => m.includes("Bad Date"));
 		expect(row).toBeTruthy();
 		// The date column should contain an indication of invalidity, not "Invalid DateTime"
 		// which is what Luxon produces without a validity check
 		expect(row).not.toMatch(/Invalid DateTime/i);
+	});
+
+	test("json option outputs valid JSON array", async () => {
+		const root = await mkdtemp(join(tmpdir(), "sandctl-tpl-list-"));
+		const store = new TemplateStore(root);
+		await store.add("Ghost");
+
+		const logSpy = spyOn(console, "log").mockImplementation(() => {});
+		try {
+			await runTemplateList({ json: true }, store);
+			expect(logSpy).toHaveBeenCalledTimes(1);
+			const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
+			expect(Array.isArray(parsed)).toBe(true);
+			expect(parsed[0]).toHaveProperty("template");
+			expect(parsed[0]).toHaveProperty("original_name", "Ghost");
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	test("json option outputs empty array when no templates", async () => {
+		const root = await mkdtemp(join(tmpdir(), "sandctl-tpl-list-"));
+		const store = new TemplateStore(root);
+
+		const logSpy = spyOn(console, "log").mockImplementation(() => {});
+		try {
+			await runTemplateList({ json: true }, store);
+			expect(logSpy).toHaveBeenCalledTimes(1);
+			const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
+			expect(parsed).toEqual([]);
+		} finally {
+			logSpy.mockRestore();
+		}
 	});
 });

--- a/tests/unit/commands/template-remove.test.ts
+++ b/tests/unit/commands/template-remove.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runTemplateRemove } from "@/commands/template-remove";
-import { TemplateNotFoundError, TemplateStore } from "@/template/store";
+import { TemplateStore } from "@/template/store";
 import type { TemplateStoreLike } from "@/template/types";
 
 describe("template remove", () => {
@@ -88,5 +88,28 @@ describe("template remove", () => {
 		});
 
 		expect(existsCalled.count).toBe(0);
+	});
+
+	test("json option skips confirmation and outputs JSON", async () => {
+		const root = await mkdtemp(join(tmpdir(), "sandctl-tpl-rm-"));
+		const store = new TemplateStore(root);
+		await store.add("Ghost");
+
+		const confirmFn = mock(async () => true);
+		const logSpy = spyOn(console, "log").mockImplementation(() => {});
+		try {
+			await runTemplateRemove("Ghost", { force: false, json: true }, store, {
+				log: () => {},
+				confirm: confirmFn,
+			});
+
+			expect(confirmFn).not.toHaveBeenCalled();
+			expect(await store.exists("Ghost")).toBe(false);
+			expect(logSpy).toHaveBeenCalledTimes(1);
+			const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
+			expect(parsed).toEqual({ name: "Ghost", removed: true });
+		} finally {
+			logSpy.mockRestore();
+		}
 	});
 });

--- a/tests/unit/commands/template-show.test.ts
+++ b/tests/unit/commands/template-show.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { describe, expect, spyOn, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runTemplateShow } from "@/commands/template-show";
@@ -12,7 +12,7 @@ describe("template show", () => {
 		await store.add("Ghost");
 
 		const output: string[] = [];
-		await runTemplateShow("Ghost", store, {
+		await runTemplateShow("Ghost", {}, store, {
 			write: (msg: string) => output.push(msg),
 		});
 
@@ -26,7 +26,7 @@ describe("template show", () => {
 		const store = new TemplateStore(root);
 
 		await expect(
-			runTemplateShow("Nope", store, { write: () => {} }),
+			runTemplateShow("Nope", {}, store, { write: () => {} }),
 		).rejects.toThrow(/not found/);
 	});
 
@@ -41,11 +41,29 @@ describe("template show", () => {
 		await writeFile(scriptPath, "#!/bin/bash\necho hello");
 
 		const output: string[] = [];
-		await runTemplateShow("Ghost", store, {
+		await runTemplateShow("Ghost", {}, store, {
 			write: (msg: string) => output.push(msg),
 		});
 
 		const joined = output.join("");
 		expect(joined.endsWith("\n")).toBe(true);
+	});
+
+	test("json option outputs name and script as JSON", async () => {
+		const root = await mkdtemp(join(tmpdir(), "sandctl-tpl-show-"));
+		const store = new TemplateStore(root);
+		await store.add("Ghost");
+
+		const logSpy = spyOn(console, "log").mockImplementation(() => {});
+		try {
+			await runTemplateShow("Ghost", { json: true }, store);
+			expect(logSpy).toHaveBeenCalledTimes(1);
+			const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
+			expect(parsed).toHaveProperty("name", "Ghost");
+			expect(parsed).toHaveProperty("script");
+			expect(parsed.script).toContain("#!/bin/bash");
+		} finally {
+			logSpy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- Adds a global `--json` flag that produces structured JSON output for all commands
- Each command emits a JSON object/array to stdout when the flag is set
- Interactive modes (exec without --command, console, template edit) ignore `--json`
- Destructive commands (destroy, template remove) skip confirmation when `--json` is used

## Commands

| Command | JSON output |
|---------|------------|
| `version` | `{version, commit, build_time}` |
| `list` | delegates to existing `--format json` |
| `template list` | array of template configs |
| `template show` | `{name, script}` |
| `template add` | template config (skips editor) |
| `template remove` | `{name, removed}` (skips confirmation) |
| `destroy` | `{id, destroyed}` (implies --force) |
| `exec --command` | `{exit_code, stdout, stderr}` |
| `new` | full Session object (skips interactive console) |
| `init` | `{config_path, saved}` (requires non-interactive flags) |

## Test plan

- [x] All 183 existing tests pass
- [x] Added new tests for JSON output in template-list, template-show, template-add, template-remove, destroy, and init
- [x] Lint clean (`npx biome check`)
- [ ] CI checks pass (lint, build, test, contract-tests, e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)