### PR TITLE
fix: extract public key from SSH agent via ssh-add

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,6 +1,8 @@
+import { execFile } from "node:child_process";
 import { readFile, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { parse } from "yaml";
 
 import { isValidEmail } from "@/utils/email";
@@ -147,6 +149,47 @@ export function setProviderSSHKeyID(
 	};
 }
 
+const execFileAsync = promisify(execFile);
+
+/**
+ * Query the SSH agent for public keys via `ssh-add -L`.
+ * If a fingerprint is provided, returns only the matching key.
+ * Otherwise returns the first key found.
+ */
+export async function getPublicKeyFromAgent(
+	fingerprint?: string,
+): Promise<string | undefined> {
+	try {
+		const { stdout } = await execFileAsync("ssh-add", ["-L"]);
+		const keys = stdout
+			.trim()
+			.split("\n")
+			.filter((line) => line.length > 0);
+		if (keys.length === 0) {
+			return undefined;
+		}
+
+		if (fingerprint) {
+			// List fingerprints to find the matching key index
+			const { stdout: fpOut } = await execFileAsync("ssh-add", ["-l"]);
+			const fpLines = fpOut
+				.trim()
+				.split("\n")
+				.filter((line) => line.length > 0);
+			for (let i = 0; i < fpLines.length && i < keys.length; i++) {
+				if (fpLines[i].includes(fingerprint)) {
+					return keys[i].trim();
+				}
+			}
+		}
+
+		// No fingerprint or no match — return the first key
+		return keys[0].trim();
+	} catch {
+		return undefined;
+	}
+}
+
 export async function getSSHPublicKey(config: Config): Promise<string> {
 	if (config.ssh_key_source === "agent") {
 		if (config.ssh_public_key_inline) {
@@ -174,9 +217,15 @@ export async function getSSHPublicKey(config: Config): Promise<string> {
 			}
 		}
 
+		// Try to get the public key from the SSH agent
+		const agentKey = await getPublicKeyFromAgent(config.ssh_key_fingerprint);
+		if (agentKey) {
+			return agentKey;
+		}
+
 		throw new ValidationError(
 			"ssh_public_key_inline",
-			"or ssh_public_key is required when ssh_key_source is 'agent' (or place your key at ~/.ssh/id_ed25519.pub)",
+			"is required when ssh_key_source is 'agent' and no key is found in the SSH agent or at ~/.ssh/id_ed25519.pub",
 		);
 	}
 

--- a/tests/unit/config/config.test.ts
+++ b/tests/unit/config/config.test.ts
@@ -15,6 +15,7 @@ import {
 	type Config,
 	getGitConfig,
 	getProviderConfig,
+	getPublicKeyFromAgent,
 	getSSHPublicKey,
 	hasGitConfig,
 	hasGitHubToken,
@@ -200,6 +201,14 @@ providers:
 		} finally {
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
+	});
+
+	test("getPublicKeyFromAgent returns undefined when no agent is available", async () => {
+		// In CI / test environments, there is typically no SSH agent
+		// so this should return undefined rather than throwing
+		const result = await getPublicKeyFromAgent();
+		// Result is either undefined (no agent) or a valid key string
+		expect(result === undefined || result.startsWith("ssh-")).toBe(true);
 	});
 
 	test("getSSHPublicKey falls back to default agent key path", async () => {


### PR DESCRIPTION
## Summary

- When `ssh_key_source: agent`, `getSSHPublicKey()` now queries the SSH agent via `ssh-add -L` as a fallback before throwing an error
- If `ssh_key_fingerprint` is configured, it matches against `ssh-add -l` output to select the correct key from the agent
- Falls back to the first key in the agent if no fingerprint match or no fingerprint configured
- Fixes the error: `config validation failed: ssh_public_key_inline is required when ssh_key_source is 'agent'`

## Context

Users with `ssh_key_source: agent` who have their key loaded in the SSH agent but no `.pub` file on disk (and no `ssh_public_key_inline` or `ssh_public_key` in config) would get a validation error. The SSH agent already has the public key — we just weren't asking it.

## Test plan

- [x] New unit test for `getPublicKeyFromAgent` 
- [x] All 184 unit tests pass
- [x] Lint clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)