### PR TITLE
fix: git config setup hangs due to SSH channel not closing

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -26,7 +26,11 @@ import {
 	type SSHClientOptions,
 } from "@/ssh/client";
 import { openConsole } from "@/ssh/console";
-import { type ExecResult, execWithStreamingOutput } from "@/ssh/exec";
+import {
+	type ExecResult,
+	execWithStreamingOutput,
+	exec as sshExec,
+} from "@/ssh/exec";
 import { TemplateNotFoundError, TemplateStore } from "@/template/store";
 import type { TemplateInitScript, TemplateStoreLike } from "@/template/types";
 import { expandTilde } from "@/utils/paths";
@@ -291,23 +295,11 @@ async function setupGitConfigViaSSH(
 	const client = deps.createSSHClient(sshOptions);
 
 	await withSSHClient(client, async (c) => {
-		const writeChannel = await c.exec(
-			`echo '${encoded}' | base64 -d > /home/agent/.gitconfig`,
-		);
-		await collectChannelOutput(writeChannel);
-
-		const chownChannel = await c.exec(
+		await sshExec(c, `echo '${encoded}' | base64 -d > /home/agent/.gitconfig`);
+		await sshExec(
+			c,
 			"chown agent:agent /home/agent/.gitconfig && chmod 644 /home/agent/.gitconfig",
 		);
-		await collectChannelOutput(chownChannel);
-	});
-}
-
-async function collectChannelOutput(channel: {
-	on(event: string, listener: (...args: unknown[]) => void): void;
-}): Promise<void> {
-	return new Promise<void>((resolve) => {
-		channel.on("close", () => resolve());
 	});
 }
 


### PR DESCRIPTION
## Summary

- Fixes the hang on "Setting up git config..." during `sandctl new`
- Root cause: `collectChannelOutput()` only listened for the `close` event on the SSH channel, which may never fire with ssh2
- Fix: replaced with the existing `exec()` helper from `ssh/exec.ts` which properly handles both `close` and `error` events with full cleanup
- Removed the now-unused `collectChannelOutput()` function

## Test plan

- [x] All 184 unit tests pass
- [x] Lint clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)