### PR TITLE
fix: persist session immediately after VM creation

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -78,7 +78,7 @@ interface NewCommandDependencies {
 interface SessionStoreLike {
 	list(): Promise<Session[]>;
 	add(session: Session): Promise<void>;
-	upsert?(session: Session): Promise<void>;
+	update(id: string, updates: Partial<Session>): Promise<void>;
 }
 
 interface Dependencies {
@@ -190,24 +190,6 @@ function messageFromError(error: unknown): string {
 		return error.message;
 	}
 	return String(error);
-}
-
-async function persistFailedSession(
-	store: SessionStoreLike,
-	session: Session,
-	warn: (message: string) => void,
-): Promise<void> {
-	try {
-		if (store.upsert) {
-			await store.upsert(session);
-			return;
-		}
-		await store.add(session);
-	} catch (error) {
-		warn(
-			`[warn] Failed to persist failed session '${session.id}': ${messageFromError(error)}`,
-		);
-	}
 }
 
 function waitReadyTimeoutMs(options: NewOptions): number {
@@ -390,6 +372,18 @@ export async function runNew(
 			image: options.image,
 			sshKeyIDs: [sshKeyID],
 		});
+
+		await dependencies.store.add({
+			id: sessionID,
+			status: "provisioning",
+			provider: providerName,
+			provider_id: createdVM.id,
+			ip_address: createdVM.ipAddress ?? "",
+			region: createdVM.region,
+			server_type: createdVM.serverType,
+			created_at: createdAt,
+		});
+
 		dependencies.log("Waiting for VM to be ready...");
 		await provider.waitReady(createdVM.id, waitReadyTimeoutMs(options));
 
@@ -432,7 +426,14 @@ export async function runNew(
 			});
 		}
 
-		const session: Session = {
+		await dependencies.store.update(sessionID, {
+			status: "running",
+			ip_address: readyVM.ipAddress ?? "",
+			region: readyVM.region,
+			server_type: readyVM.serverType,
+		});
+
+		return {
 			id: sessionID,
 			status: "running",
 			provider: providerName,
@@ -442,9 +443,6 @@ export async function runNew(
 			server_type: readyVM.serverType,
 			created_at: createdAt,
 		};
-
-		await dependencies.store.add(session);
-		return session;
 	} catch (error) {
 		if (createdVM) {
 			try {
@@ -455,21 +453,16 @@ export async function runNew(
 				);
 			}
 
-			await persistFailedSession(
-				dependencies.store,
-				{
-					id: sessionID,
+			try {
+				await dependencies.store.update(sessionID, {
 					status: "failed",
-					provider: providerName,
-					provider_id: createdVM.id,
-					ip_address: createdVM.ipAddress ?? "",
-					region: createdVM.region,
-					server_type: createdVM.serverType,
-					created_at: createdAt,
 					failure_reason: messageFromError(error),
-				},
-				dependencies.warn,
-			);
+				});
+			} catch (updateError) {
+				dependencies.warn(
+					`[warn] Failed to update session '${sessionID}': ${messageFromError(updateError)}`,
+				);
+			}
 		}
 
 		throw error;

--- a/tests/unit/commands/new-template.test.ts
+++ b/tests/unit/commands/new-template.test.ts
@@ -49,6 +49,7 @@ describe("commands/new --template", () => {
 				store: {
 					list: async () => [],
 					add: async () => {},
+					update: async () => {},
 				},
 				templateStore: {
 					getInitScript: async () => ({
@@ -112,6 +113,7 @@ describe("commands/new --template", () => {
 				store: {
 					list: async () => [],
 					add: async () => {},
+					update: async () => {},
 				},
 				templateStore: {
 					getInitScript: async () => ({

--- a/tests/unit/commands/new.test.ts
+++ b/tests/unit/commands/new.test.ts
@@ -35,6 +35,7 @@ describe("commands/new", () => {
 	test("deletes VM and persists failed session when waitReady fails", async () => {
 		const deleted: string[] = [];
 		const added: Session[] = [];
+		const updates: { id: string; updates: Partial<Session> }[] = [];
 		const provider = makeProvider({
 			waitReady: async () => {
 				throw new Error("vm never became ready");
@@ -59,6 +60,9 @@ describe("commands/new", () => {
 						add: async (session: Session) => {
 							added.push(session);
 						},
+						update: async (id: string, u: Partial<Session>) => {
+							updates.push({ id, updates: u });
+						},
 					},
 				},
 			),
@@ -68,16 +72,21 @@ describe("commands/new", () => {
 		expect(added).toHaveLength(1);
 		expect(added[0]).toMatchObject({
 			id: "violet",
-			status: "failed",
+			status: "provisioning",
 			provider: "hetzner",
 			provider_id: "vm-123",
 			ip_address: "203.0.113.10",
-			failure_reason: "vm never became ready",
+		});
+		expect(updates).toHaveLength(1);
+		expect(updates[0]).toMatchObject({
+			id: "violet",
+			updates: { status: "failed", failure_reason: "vm never became ready" },
 		});
 	});
 
 	test("persists failed session even when cleanup delete fails", async () => {
 		const added: Session[] = [];
+		const updates: { id: string; updates: Partial<Session> }[] = [];
 		const provider = makeProvider({
 			waitReady: async () => {
 				throw new Error("setup step failed");
@@ -102,6 +111,9 @@ describe("commands/new", () => {
 						add: async (session: Session) => {
 							added.push(session);
 						},
+						update: async (id: string, u: Partial<Session>) => {
+							updates.push({ id, updates: u });
+						},
 					},
 				},
 			),
@@ -110,9 +122,14 @@ describe("commands/new", () => {
 		expect(added).toHaveLength(1);
 		expect(added[0]).toMatchObject({
 			id: "violet",
-			status: "failed",
+			status: "provisioning",
 			provider: "hetzner",
 			provider_id: "vm-123",
+		});
+		expect(updates).toHaveLength(1);
+		expect(updates[0]).toMatchObject({
+			id: "violet",
+			updates: { status: "failed" },
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Persist session with status `"provisioning"` right after `provider.create()` succeeds
- Update to `"running"` on success or `"failed"` on error via `store.update()`
- Remove `persistFailedSession()` helper (no longer needed since session already exists)

This fixes an issue where `sandctl new` hanging during provisioning (cloud-init, git config, or template execution) left orphaned VMs in Hetzner with no local session record. Users had no way to discover or destroy these VMs without going to the Hetzner UI.

## Test plan

- [x] All 184 unit tests pass
- [x] Biome lint clean
- [ ] CI checks pass (lint, build, test, contract-tests, e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)