### PR TITLE
feat: enable SSH agent forwarding when using agent auth

### DIFF
--- a/src/ssh/client.ts
+++ b/src/ssh/client.ts
@@ -98,6 +98,7 @@ export class SSHClient implements SSHClientLike {
 				this.options.agentSocket ?? (await this.deps.discoverAgentSocket());
 			if (socket) {
 				config.agent = socket;
+				config.agentForward = true;
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Enable `agentForward: true` in the SSH connection config when the agent socket is available
- This forwards the local SSH agent to the remote VM, so SSH keys are usable on the VM (e.g. for `git clone`/`git push` over SSH)

One-line change in `src/ssh/client.ts`.

## Test plan

- [x] All 184 unit tests pass
- [x] Biome lint clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)