### PR TITLE
fix: use discovered agent socket when querying ssh-add for public keys

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { parse } from "yaml";
 
+import { discoverPrimaryAgentSocket } from "@/ssh/agent";
 import { isValidEmail } from "@/utils/email";
 import { expandTilde } from "@/utils/paths";
 
@@ -160,7 +161,16 @@ export async function getPublicKeyFromAgent(
 	fingerprint?: string,
 ): Promise<string | undefined> {
 	try {
-		const { stdout } = await execFileAsync("ssh-add", ["-L"]);
+		// Discover the correct agent socket — SSH_AUTH_SOCK may point to
+		// the macOS default agent while the real keys live in 1Password or
+		// another agent found via IdentityAgent in ~/.ssh/config.
+		const agentSocket = await discoverPrimaryAgentSocket();
+		const env = agentSocket
+			? { ...process.env, SSH_AUTH_SOCK: agentSocket }
+			: process.env;
+		const execOpts = { env };
+
+		const { stdout } = await execFileAsync("ssh-add", ["-L"], execOpts);
 		const keys = stdout
 			.trim()
 			.split("\n")
@@ -171,7 +181,11 @@ export async function getPublicKeyFromAgent(
 
 		if (fingerprint) {
 			// List fingerprints to find the matching key index
-			const { stdout: fpOut } = await execFileAsync("ssh-add", ["-l"]);
+			const { stdout: fpOut } = await execFileAsync(
+				"ssh-add",
+				["-l"],
+				execOpts,
+			);
 			const fpLines = fpOut
 				.trim()
 				.split("\n")

--- a/tests/unit/config/config.test.ts
+++ b/tests/unit/config/config.test.ts
@@ -211,7 +211,7 @@ providers:
 		expect(result === undefined || result.startsWith("ssh-")).toBe(true);
 	});
 
-	test("getSSHPublicKey falls back to default agent key path", async () => {
+	test("getSSHPublicKey falls back to default agent key path or agent", async () => {
 		const candidatePaths = [
 			path.join(os.homedir(), ".ssh", "id_ed25519.pub"),
 			path.join(os.homedir(), ".ssh", "id_rsa.pub"),
@@ -225,12 +225,20 @@ providers:
 			ssh_key_source: "agent",
 		};
 
-		if (!existingPath) {
-			await expect(getSSHPublicKey(config)).rejects.toThrow(ValidationError);
+		if (existingPath) {
+			const expected = readFileSync(existingPath, "utf8").trim();
+			expect(await getSSHPublicKey(config)).toBe(expected);
 			return;
 		}
 
-		const expected = readFileSync(existingPath, "utf8").trim();
-		expect(await getSSHPublicKey(config)).toBe(expected);
+		// No key file on disk — falls back to SSH agent.
+		// If an agent is reachable (e.g. 1Password via IdentityAgent),
+		// getSSHPublicKey returns a key; otherwise it throws.
+		try {
+			const key = await getSSHPublicKey(config);
+			expect(key.startsWith("ssh-")).toBe(true);
+		} catch (error) {
+			expect(error).toBeInstanceOf(ValidationError);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- `getPublicKeyFromAgent()` was running `ssh-add -L` using `SSH_AUTH_SOCK` from the environment, which on macOS points to the default agent (typically empty) rather than the actual agent (e.g. 1Password via `IdentityAgent` in `~/.ssh/config`)
- Now uses `discoverPrimaryAgentSocket()` to find the correct agent socket and passes it as `SSH_AUTH_SOCK` when invoking `ssh-add -L` and `ssh-add -l`, consistent with how `SSHClient.connect()` discovers the agent
- Updated test to handle environments where no key file exists on disk but an agent is reachable