### PR TITLE
fix: preserve existing tokens in init when user leaves prompts blank

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -137,10 +137,11 @@ export async function runInit(
 		}
 	}
 
-	const hetznerToken = await password({
-		message: "Hetzner Cloud API token",
-		mask: true,
-	});
+	const hetznerToken =
+		(await password({
+			message: `Hetzner Cloud API token${existing?.providers?.hetzner?.token ? " (leave blank to keep existing)" : ""}`,
+			mask: true,
+		})) || existing?.providers?.hetzner?.token;
 	const sshMode = await select({
 		message: "SSH key mode",
 		default: existing?.ssh_key_source === "agent" ? "agent" : "file",
@@ -215,10 +216,11 @@ export async function runInit(
 				default: existing?.git_config_path,
 			});
 
-	const githubToken = await password({
-		message: "GitHub personal access token (optional)",
-		mask: true,
-	});
+	const githubToken =
+		(await password({
+			message: `GitHub personal access token${existing?.github_token ? " (leave blank to keep existing)" : " (optional)"}`,
+			mask: true,
+		})) || existing?.github_token;
 
 	await save(
 		resolvedConfigPath,


### PR DESCRIPTION
## Summary

- `sandctl init` now preserves existing Hetzner API token and GitHub PAT when the user presses Enter without typing a new value
- Prompt message shows "(leave blank to keep existing)" when a value is already configured
- Previously, leaving these password prompts blank would overwrite the stored tokens with empty strings