### PR TITLE
feat: add `sandctl open` command

### DIFF
--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,0 +1,105 @@
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+import { Command } from "commander";
+import {
+	assertRunnable,
+	lookupSession,
+	type SessionStoreLike,
+} from "@/commands/shared/session-runtime";
+import { SessionStore } from "@/session/store";
+
+interface OpenOptions {
+	port?: string;
+	https?: boolean;
+}
+
+interface Dependencies {
+	store: SessionStoreLike;
+	openURL: (url: string) => Promise<void>;
+	log: (message: string) => void;
+}
+
+const defaultDependencies: Dependencies = {
+	store: new SessionStore(),
+	openURL: defaultOpenURL,
+	log: (message: string) => {
+		console.log(message);
+	},
+};
+
+function browserCommand(): string {
+	switch (platform()) {
+		case "darwin":
+			return "open";
+		case "win32":
+			return "start";
+		default:
+			return "xdg-open";
+	}
+}
+
+async function defaultOpenURL(url: string): Promise<void> {
+	const command = browserCommand();
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, [url], { stdio: "ignore" });
+		child.on("error", reject);
+		child.on("close", (code) => {
+			if (code === 0) {
+				resolve();
+			} else {
+				reject(new Error(`${command} exited with code ${code}`));
+			}
+		});
+	});
+}
+
+export async function runOpen(
+	name: string,
+	options: OpenOptions = {},
+	deps: Partial<Dependencies> = {},
+): Promise<string> {
+	const dependencies = {
+		...defaultDependencies,
+		...deps,
+	};
+
+	const session = await lookupSession(name, dependencies.store);
+	assertRunnable(session);
+
+	const protocol = options.https ? "https" : "http";
+	const port = options.port ?? (options.https ? "443" : "80");
+	const portSuffix =
+		(protocol === "http" && port === "80") ||
+		(protocol === "https" && port === "443")
+			? ""
+			: `:${port}`;
+	const url = `${protocol}://${session.ip_address}${portSuffix}`;
+
+	dependencies.log(`Opening ${url}...`);
+	await dependencies.openURL(url);
+
+	return url;
+}
+
+export function registerOpenCommand(): Command {
+	return new Command("open")
+		.description("Open a running session in the browser")
+		.argument("<name>")
+		.option("-p, --port <port>", "Port number")
+		.option("--https", "Use HTTPS instead of HTTP")
+		.action(async (name: string, options: OpenOptions, command: Command) => {
+			const globals = command.optsWithGlobals() as {
+				config?: string;
+				json?: boolean;
+			};
+			if (globals.json) {
+				const url = await runOpen(name, options, {
+					log: () => {},
+					openURL: async () => {},
+				});
+				console.log(JSON.stringify({ url }, null, 2));
+				return;
+			}
+			await runOpen(name, options);
+		});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { registerExecCommand } from "@/commands/exec";
 import { registerInitCommand } from "@/commands/init";
 import { registerListCommand } from "@/commands/list";
 import { registerNewCommand } from "@/commands/new";
+import { registerOpenCommand } from "@/commands/open";
 import { registerTemplateCommand } from "@/commands/template";
 import { registerVersionCommand } from "@/commands/version";
 
@@ -22,6 +23,7 @@ program.addCommand(registerNewCommand());
 program.addCommand(registerListCommand());
 program.addCommand(registerExecCommand());
 program.addCommand(registerConsoleCommand());
+program.addCommand(registerOpenCommand());
 program.addCommand(registerDestroyCommand());
 program.addCommand(registerTemplateCommand());
 

--- a/tests/unit/commands/open.test.ts
+++ b/tests/unit/commands/open.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+
+import { runOpen } from "@/commands/open";
+import { makeRunningSession } from "../../support/fixtures";
+
+describe("commands/open", () => {
+	test("opens http URL with session IP address", async () => {
+		let openedURL = "";
+
+		const url = await runOpen(
+			"alice",
+			{},
+			{
+				store: {
+					get: async () => makeRunningSession(),
+				},
+				openURL: async (u: string) => {
+					openedURL = u;
+				},
+				log: () => {},
+			},
+		);
+
+		expect(url).toBe("http://203.0.113.10");
+		expect(openedURL).toBe("http://203.0.113.10");
+	});
+
+	test("opens https URL when --https flag is set", async () => {
+		let openedURL = "";
+
+		const url = await runOpen(
+			"alice",
+			{ https: true },
+			{
+				store: {
+					get: async () => makeRunningSession(),
+				},
+				openURL: async (u: string) => {
+					openedURL = u;
+				},
+				log: () => {},
+			},
+		);
+
+		expect(url).toBe("https://203.0.113.10");
+		expect(openedURL).toBe("https://203.0.113.10");
+	});
+
+	test("includes port in URL when specified", async () => {
+		const url = await runOpen(
+			"alice",
+			{ port: "3000" },
+			{
+				store: {
+					get: async () => makeRunningSession(),
+				},
+				openURL: async () => {},
+				log: () => {},
+			},
+		);
+
+		expect(url).toBe("http://203.0.113.10:3000");
+	});
+
+	test("omits default port 80 for http", async () => {
+		const url = await runOpen(
+			"alice",
+			{ port: "80" },
+			{
+				store: {
+					get: async () => makeRunningSession(),
+				},
+				openURL: async () => {},
+				log: () => {},
+			},
+		);
+
+		expect(url).toBe("http://203.0.113.10");
+	});
+
+	test("omits default port 443 for https", async () => {
+		const url = await runOpen(
+			"alice",
+			{ port: "443", https: true },
+			{
+				store: {
+					get: async () => makeRunningSession(),
+				},
+				openURL: async () => {},
+				log: () => {},
+			},
+		);
+
+		expect(url).toBe("https://203.0.113.10");
+	});
+
+	test("rejects with exit code 5 when session is not running", async () => {
+		await expect(
+			runOpen(
+				"alice",
+				{},
+				{
+					store: {
+						get: async () => makeRunningSession({ status: "failed" }),
+					},
+					openURL: async () => {},
+					log: () => {},
+				},
+			),
+		).rejects.toMatchObject({
+			exitCode: 5,
+		});
+	});
+
+	test("normalizes session name", async () => {
+		let lookedUp = "";
+
+		await runOpen(
+			"Alice",
+			{},
+			{
+				store: {
+					get: async (id: string) => {
+						lookedUp = id;
+						return makeRunningSession();
+					},
+				},
+				openURL: async () => {},
+				log: () => {},
+			},
+		);
+
+		expect(lookedUp).toBe("alice");
+	});
+});


### PR DESCRIPTION
## Summary

- New `sandctl open <session>` command that opens a running session's IP in the default browser
- Supports `--port <port>` for custom ports (e.g. `sandctl open ghost-vm --port 3000`)
- Supports `--https` for HTTPS URLs
- Supports `--json` to output the URL without opening the browser
- Cross-platform: uses `open` on macOS, `xdg-open` on Linux

This makes it easy to access services running on a VM (like Ghost) without having to look up the IP address in the Hetzner UI.

## Test plan

- [x] 7 unit tests covering URL construction, port handling, HTTPS, error cases
- [x] All 191 tests pass
- [x] Biome lint clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)