### PR TITLE
perf: skip provider sync in list command by default

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -165,7 +165,7 @@ async function syncProviderSessions(
 }
 
 export async function runList(
-	options: { format: string; all: boolean },
+	options: { format: string; all: boolean; sync?: boolean },
 	store = new SessionStore(),
 	deps: Partial<Dependencies> = {},
 	configPath?: string,
@@ -186,7 +186,9 @@ export async function runList(
 		}
 	}
 
-	await syncProviderSessions(sessions, store, dependencies, configPath);
+	if (options.sync) {
+		await syncProviderSessions(sessions, store, dependencies, configPath);
+	}
 
 	if (!options.all) {
 		sessions = sessions.filter(
@@ -226,14 +228,24 @@ export function registerListCommand(): Command {
 			"table",
 		)
 		.option("-a, --all", "Include stopped and failed sessions", false)
-		.action(async (options: { format: string; all: boolean }, command) => {
-			const globals = command.optsWithGlobals() as {
-				config?: string;
-				json?: boolean;
-			};
-			if (globals.json) {
-				options.format = "json";
-			}
-			await runList(options, undefined, undefined, globals.config);
-		});
+		.option(
+			"--sync",
+			"Sync session status with the cloud provider (slower)",
+			false,
+		)
+		.action(
+			async (
+				options: { format: string; all: boolean; sync: boolean },
+				command,
+			) => {
+				const globals = command.optsWithGlobals() as {
+					config?: string;
+					json?: boolean;
+				};
+				if (globals.json) {
+					options.format = "json";
+				}
+				await runList(options, undefined, undefined, globals.config);
+			},
+		);
 }

--- a/tests/unit/commands/list.test.ts
+++ b/tests/unit/commands/list.test.ts
@@ -88,7 +88,7 @@ describe("commands/list", () => {
 
 	test("provider sync updates session status", async () => {
 		await store.add(runningSession);
-		await runList({ format: "table", all: true }, store, {
+		await runList({ format: "table", all: true, sync: true }, store, {
 			loadConfig: async () => baseProviderConfig,
 			resolveProvider: () =>
 				makeProvider([
@@ -108,7 +108,7 @@ describe("commands/list", () => {
 
 	test("unknown providers are handled without failing", async () => {
 		await store.add({ ...runningSession, provider: "unknown" });
-		await runList({ format: "table", all: true }, store, {
+		await runList({ format: "table", all: true, sync: true }, store, {
 			loadConfig: async () => baseProviderConfig,
 		});
 		expect((await store.get("alice")).status).toBe("running");
@@ -117,7 +117,7 @@ describe("commands/list", () => {
 
 	test("missing vm in provider list marks active session as stopped", async () => {
 		await store.add(runningSession);
-		await runList({ format: "table", all: true }, store, {
+		await runList({ format: "table", all: true, sync: true }, store, {
 			loadConfig: async () => baseProviderConfig,
 			resolveProvider: () => makeProvider([]),
 		});
@@ -130,7 +130,7 @@ describe("commands/list", () => {
 		provider.list = async () => {
 			throw new Error("sync unavailable");
 		};
-		await runList({ format: "table", all: true }, store, {
+		await runList({ format: "table", all: true, sync: true }, store, {
 			loadConfig: async () => baseProviderConfig,
 			resolveProvider: () => provider,
 		});
@@ -145,7 +145,7 @@ describe("commands/list", () => {
 
 	test("provider resolution failures fall back to local session data", async () => {
 		await store.add(runningSession);
-		await runList({ format: "table", all: true }, store, {
+		await runList({ format: "table", all: true, sync: true }, store, {
 			loadConfig: async () => baseProviderConfig,
 			resolveProvider: () => {
 				throw new Error("registry unavailable");
@@ -213,7 +213,7 @@ describe("commands/list", () => {
 			]);
 		};
 
-		await runList({ format: "table", all: true }, store, {
+		await runList({ format: "table", all: true, sync: true }, store, {
 			loadConfig: async () => baseProviderConfig,
 			resolveProvider: () => provider,
 		});


### PR DESCRIPTION
## Summary

- `sandctl list` now reads from the local session store only — no API calls, instant results
- Added `--sync` flag to opt into verifying session status against the cloud provider
- Previously every `sandctl list` hit the Hetzner API, making it slow for quick session switching

### Usage

```bash
sandctl list          # fast, local store only
sandctl list --sync   # slower, verifies against Hetzner
```

## Test plan

- [x] All 184 tests pass (sync tests updated to use `sync: true`)
- [x] Biome lint clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)