### PR TITLE
Add `sandctl extend` command to extend session timeouts

### DIFF
--- a/src/commands/extend.ts
+++ b/src/commands/extend.ts
@@ -1,0 +1,103 @@
+import { Command } from "commander";
+
+import { normalizeName, validateID } from "@/session/id";
+import { SessionStore } from "@/session/store";
+import {
+	age,
+	Duration,
+	isActive,
+	NotFoundError,
+	timeoutRemaining,
+} from "@/session/types";
+
+export interface ExtendResult {
+	id: string;
+	timeout: string;
+	expires_in: string;
+}
+
+export async function runExtend(
+	name: string,
+	duration: string,
+	options: { silent?: boolean },
+	store = new SessionStore(),
+): Promise<ExtendResult> {
+	const normalized = normalizeName(name);
+	if (!validateID(normalized)) {
+		throw new Error(`invalid session name format: ${name}`);
+	}
+
+	const extension = Duration.parse(duration);
+
+	const session = await store.get(normalized).catch((error: unknown) => {
+		if (error instanceof NotFoundError) {
+			throw new Error(
+				`Session '${normalized}' not found. Use 'sandctl list' to see available sessions.`,
+			);
+		}
+		throw error;
+	});
+
+	if (!isActive(session)) {
+		throw new Error(
+			`Session '${normalized}' is ${session.status}. Only active sessions can be extended.`,
+		);
+	}
+
+	let newTimeout: Duration;
+	if (session.timeout) {
+		const currentTimeout = Duration.parse(session.timeout);
+		newTimeout = new Duration(
+			currentTimeout.milliseconds + extension.milliseconds,
+		);
+	} else {
+		// No timeout set — set it to session age + requested duration
+		const sessionAge = age(session);
+		newTimeout = new Duration(sessionAge + extension.milliseconds);
+	}
+
+	await store.update(normalized, { timeout: newTimeout.toString() });
+
+	const updated = await store.get(normalized);
+	const remaining = timeoutRemaining(updated);
+	const expiresIn =
+		remaining !== null ? new Duration(remaining).toString() : duration;
+
+	if (!options.silent) {
+		console.log(
+			`Extended session ${normalized} by ${extension.toString()} (expires in ${expiresIn})`,
+		);
+	}
+
+	return {
+		id: normalized,
+		timeout: newTimeout.toString(),
+		expires_in: expiresIn,
+	};
+}
+
+export function registerExtendCommand(): Command {
+	return new Command("extend")
+		.description("Extend the timeout of an active session")
+		.argument("<name>", "Session name")
+		.argument("<duration>", 'Duration to add (e.g. "1h", "30m", "1h30m")')
+		.action(
+			async (
+				name: string,
+				duration: string,
+				_options: unknown,
+				command: Command,
+			) => {
+				const globals = command.optsWithGlobals() as {
+					config?: string;
+					json?: boolean;
+				};
+				const result = await runExtend(name, duration, {
+					silent: globals.json,
+				});
+				if (globals.json) {
+					console.log(JSON.stringify(result, null, 2));
+				}
+			},
+		);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { registerConsoleCommand } from "@/commands/console";
 import { registerDestroyCommand } from "@/commands/destroy";
 import { registerExecCommand } from "@/commands/exec";
+import { registerExtendCommand } from "@/commands/extend";
 import { registerInitCommand } from "@/commands/init";
 import { registerListCommand } from "@/commands/list";
 import { registerNewCommand } from "@/commands/new";
@@ -25,6 +26,7 @@ program.addCommand(registerExecCommand());
 program.addCommand(registerConsoleCommand());
 program.addCommand(registerOpenCommand());
 program.addCommand(registerDestroyCommand());
+program.addCommand(registerExtendCommand());
 program.addCommand(registerTemplateCommand());
 
 if (import.meta.main) {

--- a/tests/unit/commands/extend.test.ts
+++ b/tests/unit/commands/extend.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runExtend } from "@/commands/extend";
+import { SessionStore } from "@/session/store";
+import { makeRunningSession } from "../../support/fixtures";
+
+describe("commands/extend", () => {
+	let store: SessionStore;
+	let logSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(async () => {
+		const dir = await mkdtemp(join(tmpdir(), "sandctl-extend-test-"));
+		store = new SessionStore(join(dir, "sessions.json"));
+		logSpy = spyOn(console, "log").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+	});
+
+	test("extends an active session with an existing timeout", async () => {
+		await store.add(
+			makeRunningSession({
+				id: "alice",
+				created_at: new Date().toISOString(),
+				timeout: "2h0m0s",
+			}),
+		);
+
+		const result = await runExtend("alice", "1h", {}, store);
+
+		expect(result.id).toBe("alice");
+		expect(result.timeout).toBe("3h0m0s");
+
+		// Verify the store was updated
+		const session = await store.get("alice");
+		expect(session.timeout).toBe("3h0m0s");
+
+		expect(logSpy).toHaveBeenCalled();
+		const logCall = logSpy.mock.calls[0][0] as string;
+		expect(logCall).toContain("Extended session alice by 1h0m0s");
+	});
+
+	test("sets timeout based on age when session has no prior timeout", async () => {
+		// Session created 30 minutes ago with no timeout
+		const thirtyMinAgo = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+		await store.add(
+			makeRunningSession({
+				id: "bob",
+				created_at: thirtyMinAgo,
+			}),
+		);
+
+		const result = await runExtend("bob", "1h", {}, store);
+
+		expect(result.id).toBe("bob");
+		// Timeout should be ~1h30m (age of 30m + extension of 1h)
+		const session = await store.get("bob");
+		expect(session.timeout).toBeDefined();
+
+		// The new timeout should give approximately 1h remaining
+		// (age ~30m + timeout should leave ~1h)
+		// We check that the timeout is approximately 1h30m (±5s tolerance)
+		expect(session.timeout).toMatch(/^1h30m\d+s$/);
+	});
+
+	test("throws error when extending a stopped session", async () => {
+		await store.add(
+			makeRunningSession({
+				id: "stopped",
+				status: "stopped",
+				timeout: "1h0m0s",
+			}),
+		);
+
+		await expect(runExtend("stopped", "1h", {}, store)).rejects.toThrow(
+			"Session 'stopped' is stopped. Only active sessions can be extended.",
+		);
+	});
+
+	test("throws error when extending a failed session", async () => {
+		await store.add(
+			makeRunningSession({
+				id: "failed",
+				status: "failed",
+				timeout: "1h0m0s",
+			}),
+		);
+
+		await expect(runExtend("failed", "1h", {}, store)).rejects.toThrow(
+			"Only active sessions can be extended.",
+		);
+	});
+
+	test("throws error for invalid duration format", async () => {
+		await store.add(makeRunningSession({ id: "alice" }));
+
+		await expect(runExtend("alice", "notaduration", {}, store)).rejects.toThrow(
+			"invalid duration",
+		);
+	});
+
+	test("throws error for non-existent session", async () => {
+		await expect(runExtend("nonexistent", "1h", {}, store)).rejects.toThrow(
+			"not found",
+		);
+	});
+
+	test("throws error for invalid session name format", async () => {
+		await expect(
+			runExtend("INVALID-NAME-123", "1h", {}, store),
+		).rejects.toThrow("invalid session name format");
+	});
+
+	test("json mode suppresses console output and returns result", async () => {
+		await store.add(
+			makeRunningSession({
+				id: "alice",
+				created_at: new Date().toISOString(),
+				timeout: "2h0m0s",
+			}),
+		);
+
+		const result = await runExtend("alice", "30m", { silent: true }, store);
+
+		expect(result.id).toBe("alice");
+		expect(result.timeout).toBe("2h30m0s");
+		expect(result.expires_in).toBeDefined();
+		expect(logSpy).not.toHaveBeenCalled();
+	});
+
+	test("extends a provisioning session", async () => {
+		await store.add(
+			makeRunningSession({
+				id: "prov",
+				status: "provisioning",
+				created_at: new Date().toISOString(),
+				timeout: "1h0m0s",
+			}),
+		);
+
+		const result = await runExtend("prov", "2h", {}, store);
+
+		expect(result.id).toBe("prov");
+		expect(result.timeout).toBe("3h0m0s");
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `sandctl extend <session-id> <duration>` command that extends an active session's timeout by the given duration
- If the session already has a timeout, the extension is added to it (e.g., "2h" + "1h" = "3h")
- If the session has no timeout set, calculates timeout from session age + requested duration so the session expires after the requested duration from now
- Validates session exists and is active (rejects stopped/failed sessions)
- Supports `--json` global flag for machine-readable output
- Shows human-friendly confirmation: "Extended session abc123 by 1h0m0s (expires in 2h30m0s)"

This is the natural complement to `sandctl reap` — users need a way to keep valuable sessions alive before they expire, without having to destroy and recreate them.

## Test plan

- [x] Unit tests covering:
  - Normal extend with existing timeout
  - Extend with no prior timeout (calculates from age)
  - Extend on stopped session (error)
  - Extend on failed session (error)
  - Invalid duration format (error)
  - Non-existent session (error)
  - Invalid session name format (error)
  - JSON output mode (silent flag)
  - Extending a provisioning session
- [x] All 200 unit tests pass
- [x] Biome lint clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)