### PR TITLE
feat: add `sandctl cp` command for file transfer via SFTP

### DIFF
--- a/src/commands/cp.ts
+++ b/src/commands/cp.ts
@@ -1,0 +1,465 @@
+import { mkdir, readdir, stat } from "node:fs/promises";
+import { dirname, join, posix } from "node:path";
+import { Command } from "commander";
+import {
+	assertRunnable,
+	buildSSHOptions,
+	lookupSession,
+	type SessionStoreLike,
+	type SSHRuntimeClient,
+	withSSHClient,
+} from "@/commands/shared/session-runtime";
+import { type Config, load } from "@/config/config";
+import { SessionStore } from "@/session/store";
+import {
+	type SFTPWrapperLike,
+	SSHClient,
+	type SSHClientLike,
+	type SSHClientOptions,
+} from "@/ssh/client";
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+interface RemoteTarget {
+	session: string;
+	path: string;
+}
+
+type CpTarget =
+	| { kind: "local"; path: string }
+	| { kind: "remote"; session: string; path: string };
+
+export function parseTarget(arg: string): CpTarget {
+	const colonIndex = arg.indexOf(":");
+	if (colonIndex <= 0) {
+		return { kind: "local", path: arg };
+	}
+	return {
+		kind: "remote",
+		session: arg.slice(0, colonIndex),
+		path: arg.slice(colonIndex + 1),
+	};
+}
+
+export function resolveDirection(
+	source: CpTarget,
+	destination: CpTarget,
+):
+	| { direction: "upload"; local: string; remote: RemoteTarget }
+	| { direction: "download"; remote: RemoteTarget; local: string } {
+	if (source.kind === "local" && destination.kind === "remote") {
+		return {
+			direction: "upload",
+			local: source.path,
+			remote: { session: destination.session, path: destination.path },
+		};
+	}
+	if (source.kind === "remote" && destination.kind === "local") {
+		return {
+			direction: "download",
+			remote: { session: source.session, path: source.path },
+			local: destination.path,
+		};
+	}
+	if (source.kind === "remote" && destination.kind === "remote") {
+		throw new Error(
+			"Remote-to-remote copy is not supported. Copy to local first, then upload.",
+		);
+	}
+	throw new Error(
+		"Both source and destination are local. Use session:path syntax for the remote side.",
+	);
+}
+
+// ---------------------------------------------------------------------------
+// SFTP helpers
+// ---------------------------------------------------------------------------
+
+function sftpFastPut(
+	sftp: SFTPWrapperLike,
+	localPath: string,
+	remotePath: string,
+	onStep?: (total: number, nb: number, fsize: number) => void,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		sftp.fastPut(localPath, remotePath, { step: onStep }, (err) => {
+			if (err) {
+				reject(err instanceof Error ? err : new Error(String(err)));
+				return;
+			}
+			resolve();
+		});
+	});
+}
+
+function sftpFastGet(
+	sftp: SFTPWrapperLike,
+	remotePath: string,
+	localPath: string,
+	onStep?: (total: number, nb: number, fsize: number) => void,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		sftp.fastGet(remotePath, localPath, { step: onStep }, (err) => {
+			if (err) {
+				reject(err instanceof Error ? err : new Error(String(err)));
+				return;
+			}
+			resolve();
+		});
+	});
+}
+
+function sftpMkdir(sftp: SFTPWrapperLike, path: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		sftp.mkdir(path, (err) => {
+			if (err) {
+				reject(err instanceof Error ? err : new Error(String(err)));
+				return;
+			}
+			resolve();
+		});
+	});
+}
+
+function sftpStat(
+	sftp: SFTPWrapperLike,
+	path: string,
+): Promise<{ isDirectory: boolean; size: number }> {
+	return new Promise((resolve, reject) => {
+		sftp.stat(path, (err, stats) => {
+			if (err) {
+				reject(err instanceof Error ? err : new Error(String(err)));
+				return;
+			}
+			resolve({ isDirectory: stats.isDirectory(), size: stats.size });
+		});
+	});
+}
+
+function sftpReaddir(
+	sftp: SFTPWrapperLike,
+	path: string,
+): Promise<Array<{ filename: string; isDirectory: boolean }>> {
+	return new Promise((resolve, reject) => {
+		sftp.readdir(path, (err, list) => {
+			if (err) {
+				reject(err instanceof Error ? err : new Error(String(err)));
+				return;
+			}
+			resolve(
+				list.map((entry) => ({
+					filename: entry.filename,
+					isDirectory: entry.attrs.isDirectory(),
+				})),
+			);
+		});
+	});
+}
+
+async function sftpMkdirRecursive(
+	sftp: SFTPWrapperLike,
+	dirPath: string,
+): Promise<void> {
+	const parts = dirPath.split("/").filter(Boolean);
+	let current = dirPath.startsWith("/") ? "/" : "";
+	for (const part of parts) {
+		current = current ? posix.join(current, part) : part;
+		try {
+			await sftpMkdir(sftp, current);
+		} catch {
+			// directory may already exist
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Transfer result
+// ---------------------------------------------------------------------------
+
+export interface TransferResult {
+	filesTransferred: number;
+	bytesTransferred: number;
+}
+
+// ---------------------------------------------------------------------------
+// Upload (local → remote)
+// ---------------------------------------------------------------------------
+
+async function uploadFile(
+	sftp: SFTPWrapperLike,
+	localPath: string,
+	remotePath: string,
+): Promise<TransferResult> {
+	let bytesTransferred = 0;
+	await sftpFastPut(sftp, localPath, remotePath, (total, _nb, _fsize) => {
+		bytesTransferred = total;
+	});
+	return { filesTransferred: 1, bytesTransferred };
+}
+
+async function uploadDirectory(
+	sftp: SFTPWrapperLike,
+	localPath: string,
+	remotePath: string,
+): Promise<TransferResult> {
+	let filesTransferred = 0;
+	let bytesTransferred = 0;
+
+	await sftpMkdirRecursive(sftp, remotePath);
+
+	const entries = await readdir(localPath, { withFileTypes: true });
+	for (const entry of entries) {
+		const localChild = join(localPath, entry.name);
+		const remoteChild = posix.join(remotePath, entry.name);
+
+		if (entry.isDirectory()) {
+			const sub = await uploadDirectory(sftp, localChild, remoteChild);
+			filesTransferred += sub.filesTransferred;
+			bytesTransferred += sub.bytesTransferred;
+		} else if (entry.isFile()) {
+			const sub = await uploadFile(sftp, localChild, remoteChild);
+			filesTransferred += sub.filesTransferred;
+			bytesTransferred += sub.bytesTransferred;
+		}
+	}
+
+	return { filesTransferred, bytesTransferred };
+}
+
+// ---------------------------------------------------------------------------
+// Download (remote → local)
+// ---------------------------------------------------------------------------
+
+async function downloadFile(
+	sftp: SFTPWrapperLike,
+	remotePath: string,
+	localPath: string,
+): Promise<TransferResult> {
+	await mkdir(dirname(localPath), { recursive: true });
+	let bytesTransferred = 0;
+	await sftpFastGet(sftp, remotePath, localPath, (total, _nb, _fsize) => {
+		bytesTransferred = total;
+	});
+	return { filesTransferred: 1, bytesTransferred };
+}
+
+async function downloadDirectory(
+	sftp: SFTPWrapperLike,
+	remotePath: string,
+	localPath: string,
+): Promise<TransferResult> {
+	let filesTransferred = 0;
+	let bytesTransferred = 0;
+
+	await mkdir(localPath, { recursive: true });
+
+	const entries = await sftpReaddir(sftp, remotePath);
+	for (const entry of entries) {
+		if (entry.filename === "." || entry.filename === "..") {
+			continue;
+		}
+
+		const remoteChild = posix.join(remotePath, entry.filename);
+		const localChild = join(localPath, entry.filename);
+
+		if (entry.isDirectory) {
+			const sub = await downloadDirectory(sftp, remoteChild, localChild);
+			filesTransferred += sub.filesTransferred;
+			bytesTransferred += sub.bytesTransferred;
+		} else {
+			const sub = await downloadFile(sftp, remoteChild, localChild);
+			filesTransferred += sub.filesTransferred;
+			bytesTransferred += sub.bytesTransferred;
+		}
+	}
+
+	return { filesTransferred, bytesTransferred };
+}
+
+// ---------------------------------------------------------------------------
+// Core cp logic
+// ---------------------------------------------------------------------------
+
+interface CpOptions {
+	recursive?: boolean;
+}
+
+interface WritableLike {
+	write(chunk: string | Uint8Array): boolean;
+}
+
+export interface CpDependencies {
+	store: SessionStoreLike;
+	loadConfig: (configPath?: string) => Promise<Config>;
+	createSSHClient: (options: SSHClientOptions) => SSHRuntimeClient;
+	openSFTP: (client: SSHClientLike) => Promise<SFTPWrapperLike>;
+	localStat: (path: string) => Promise<{ isDirectory: boolean }>;
+	remoteStat: (
+		sftp: SFTPWrapperLike,
+		path: string,
+	) => Promise<{ isDirectory: boolean; size: number }>;
+	uploadFile: (
+		sftp: SFTPWrapperLike,
+		localPath: string,
+		remotePath: string,
+	) => Promise<TransferResult>;
+	uploadDirectory: (
+		sftp: SFTPWrapperLike,
+		localPath: string,
+		remotePath: string,
+	) => Promise<TransferResult>;
+	downloadFile: (
+		sftp: SFTPWrapperLike,
+		remotePath: string,
+		localPath: string,
+	) => Promise<TransferResult>;
+	downloadDirectory: (
+		sftp: SFTPWrapperLike,
+		remotePath: string,
+		localPath: string,
+	) => Promise<TransferResult>;
+	stdout: WritableLike;
+	stderr: WritableLike;
+}
+
+const defaultDependencies: CpDependencies = {
+	store: new SessionStore(),
+	loadConfig: load,
+	createSSHClient: (options) => new SSHClient(options),
+	openSFTP: (client) => client.sftp(),
+	localStat: async (path) => {
+		const s = await stat(path);
+		return { isDirectory: s.isDirectory() };
+	},
+	remoteStat: sftpStat,
+	uploadFile,
+	uploadDirectory,
+	downloadFile,
+	downloadDirectory,
+	stdout: process.stdout,
+	stderr: process.stderr,
+};
+
+export async function runCp(
+	source: string,
+	destination: string,
+	options: CpOptions,
+	deps: Partial<CpDependencies> = {},
+	configPath?: string,
+): Promise<TransferResult> {
+	const d = { ...defaultDependencies, ...deps };
+
+	const src = parseTarget(source);
+	const dst = parseTarget(destination);
+	const plan = resolveDirection(src, dst);
+
+	const session = await lookupSession(plan.remote.session, d.store);
+	assertRunnable(session);
+
+	const config = await d.loadConfig(configPath);
+	const client = d.createSSHClient(buildSSHOptions(config, session.ip_address));
+
+	return withSSHClient(client, async (c) => {
+		const sftp = await d.openSFTP(c);
+
+		try {
+			if (plan.direction === "upload") {
+				const localInfo = await d.localStat(plan.local);
+
+				if (localInfo.isDirectory) {
+					if (!options.recursive) {
+						throw new Error(
+							`'${plan.local}' is a directory. Use -r to copy directories.`,
+						);
+					}
+					return await d.uploadDirectory(sftp, plan.local, plan.remote.path);
+				}
+				return await d.uploadFile(sftp, plan.local, plan.remote.path);
+			}
+
+			// download
+			let remoteIsDir: boolean;
+			try {
+				const remoteInfo = await d.remoteStat(sftp, plan.remote.path);
+				remoteIsDir = remoteInfo.isDirectory;
+			} catch {
+				throw new Error(`Remote path '${plan.remote.path}' not found.`);
+			}
+
+			if (remoteIsDir) {
+				if (!options.recursive) {
+					throw new Error(
+						`'${plan.remote.path}' is a directory. Use -r to copy directories.`,
+					);
+				}
+				return await d.downloadDirectory(sftp, plan.remote.path, plan.local);
+			}
+			return await d.downloadFile(sftp, plan.remote.path, plan.local);
+		} finally {
+			sftp.end();
+		}
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	if (bytes < 1024 * 1024 * 1024)
+		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+export function registerCpCommand(): Command {
+	return new Command("cp")
+		.description("Copy files between local machine and a sandbox session")
+		.argument("<source>", "Source path (local or session:/remote/path)")
+		.argument(
+			"<destination>",
+			"Destination path (local or session:/remote/path)",
+		)
+		.option("-r, --recursive", "Copy directories recursively")
+		.action(
+			async (
+				source: string,
+				destination: string,
+				options: CpOptions,
+				command: Command,
+			): Promise<void> => {
+				const globals = command.optsWithGlobals() as {
+					config?: string;
+					json?: boolean;
+				};
+
+				const result = await runCp(
+					source,
+					destination,
+					options,
+					{},
+					globals.config,
+				);
+
+				if (globals.json) {
+					console.log(
+						JSON.stringify(
+							{
+								files_transferred: result.filesTransferred,
+								bytes_transferred: result.bytesTransferred,
+							},
+							null,
+							2,
+						),
+					);
+				} else {
+					console.log(
+						`Transferred ${result.filesTransferred} file${result.filesTransferred === 1 ? "" : "s"} (${formatBytes(result.bytesTransferred)})`,
+					);
+				}
+			},
+		);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 
 import { registerConsoleCommand } from "@/commands/console";
+import { registerCpCommand } from "@/commands/cp";
 import { registerDestroyCommand } from "@/commands/destroy";
 import { registerExecCommand } from "@/commands/exec";
 import { registerExtendCommand } from "@/commands/extend";
@@ -23,6 +24,7 @@ program.addCommand(registerInitCommand());
 program.addCommand(registerNewCommand());
 program.addCommand(registerListCommand());
 program.addCommand(registerExecCommand());
+program.addCommand(registerCpCommand());
 program.addCommand(registerConsoleCommand());
 program.addCommand(registerOpenCommand());
 program.addCommand(registerDestroyCommand());

--- a/src/ssh/client.ts
+++ b/src/ssh/client.ts
@@ -25,6 +25,42 @@ export interface SSHShellChannelLike extends SSHExecChannelLike {
 	setWindow(rows: number, cols: number, height: number, width: number): void;
 }
 
+export interface SFTPStats {
+	isDirectory(): boolean;
+	isFile(): boolean;
+	size: number;
+}
+
+export interface SFTPFileEntry {
+	filename: string;
+	attrs: SFTPStats;
+}
+
+export interface SFTPWrapperLike {
+	fastPut(
+		localPath: string,
+		remotePath: string,
+		options: { step?: (total: number, nb: number, fsize: number) => void },
+		callback: (err?: Error | null) => void,
+	): void;
+	fastGet(
+		remotePath: string,
+		localPath: string,
+		options: { step?: (total: number, nb: number, fsize: number) => void },
+		callback: (err?: Error | null) => void,
+	): void;
+	readdir(
+		path: string,
+		callback: (err: Error | undefined, list: SFTPFileEntry[]) => void,
+	): void;
+	stat(
+		path: string,
+		callback: (err: Error | undefined, stats: SFTPStats) => void,
+	): void;
+	mkdir(path: string, callback: (err?: Error | null) => void): void;
+	end(): void;
+}
+
 export interface SSHConnectionLike {
 	connect(config: Record<string, unknown>): void;
 	on(event: string, listener: (...args: unknown[]) => void): SSHConnectionLike;
@@ -40,6 +76,7 @@ export interface SSHConnectionLike {
 		window: { term: string; cols: number; rows: number },
 		callback: (error?: Error, channel?: SSHShellChannelLike) => void,
 	): void;
+	sftp(callback: (error?: Error, sftp?: SFTPWrapperLike) => void): void;
 	end(): void;
 }
 
@@ -62,6 +99,7 @@ export interface SSHClientLike {
 		cols?: number;
 		rows?: number;
 	}): Promise<SSHShellChannelLike>;
+	sftp(): Promise<SFTPWrapperLike>;
 }
 
 export class SSHClient implements SSHClientLike {
@@ -143,6 +181,22 @@ export class SSHClient implements SSHClientLike {
 					return;
 				}
 				resolve(channel);
+			});
+		});
+	}
+
+	async sftp(): Promise<SFTPWrapperLike> {
+		if (!this.connected) {
+			throw new Error("ssh client is not connected");
+		}
+
+		return await new Promise<SFTPWrapperLike>((resolve, reject) => {
+			this.connection.sftp((error, sftp) => {
+				if (error || !sftp) {
+					reject(error ?? new Error("failed to open sftp session"));
+					return;
+				}
+				resolve(sftp);
 			});
 		});
 	}

--- a/tests/unit/commands/cp.test.ts
+++ b/tests/unit/commands/cp.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	type CpDependencies,
+	parseTarget,
+	resolveDirection,
+	runCp,
+} from "@/commands/cp";
+import type { Config } from "@/config/config";
+import type { SFTPWrapperLike } from "@/ssh/client";
+import { makeRunningSession } from "../../support/fixtures";
+
+const FILE_MODE_CONFIG: Config = {
+	default_provider: "hetzner",
+	ssh_public_key: "~/.ssh/id_ed25519.pub",
+};
+
+function makeMockSSHClient(events: string[]) {
+	return {
+		connect: async () => {
+			events.push("client.connect");
+		},
+		close: async () => {
+			events.push("client.close");
+		},
+		exec: async () => {
+			throw new Error("not used");
+		},
+		shell: async () => {
+			throw new Error("not used");
+		},
+		sftp: async () => {
+			throw new Error("not used");
+		},
+	};
+}
+
+function makeMockSFTP(): SFTPWrapperLike {
+	return {
+		fastPut: (_l, _r, _o, cb) => cb(),
+		fastGet: (_r, _l, _o, cb) => cb(),
+		readdir: (_p, cb) => cb(undefined, []),
+		stat: (_p, cb) =>
+			cb(undefined, {
+				isDirectory: () => false,
+				isFile: () => true,
+				size: 100,
+			}),
+		mkdir: (_p, cb) => cb(),
+		end: () => {},
+	};
+}
+
+function makeBaseDeps(
+	overrides: Partial<CpDependencies> = {},
+): Partial<CpDependencies> {
+	const events: string[] = [];
+	return {
+		store: {
+			get: async () => makeRunningSession(),
+		},
+		loadConfig: async () => FILE_MODE_CONFIG,
+		createSSHClient: () => makeMockSSHClient(events),
+		openSFTP: async () => makeMockSFTP(),
+		localStat: async () => ({ isDirectory: false }),
+		remoteStat: async () => ({ isDirectory: false, size: 100 }),
+		uploadFile: async () => ({ filesTransferred: 1, bytesTransferred: 100 }),
+		uploadDirectory: async () => ({
+			filesTransferred: 3,
+			bytesTransferred: 300,
+		}),
+		downloadFile: async () => ({
+			filesTransferred: 1,
+			bytesTransferred: 200,
+		}),
+		downloadDirectory: async () => ({
+			filesTransferred: 5,
+			bytesTransferred: 500,
+		}),
+		stdout: { write: () => true },
+		stderr: { write: () => true },
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+describe("parseTarget", () => {
+	test("parses a local path", () => {
+		expect(parseTarget("./file.txt")).toEqual({
+			kind: "local",
+			path: "./file.txt",
+		});
+	});
+
+	test("parses a remote path with session prefix", () => {
+		expect(parseTarget("mysession:/home/agent/file.txt")).toEqual({
+			kind: "remote",
+			session: "mysession",
+			path: "/home/agent/file.txt",
+		});
+	});
+
+	test("treats path starting with colon as local", () => {
+		expect(parseTarget(":/some/path")).toEqual({
+			kind: "local",
+			path: ":/some/path",
+		});
+	});
+
+	test("handles relative remote paths", () => {
+		expect(parseTarget("alice:file.txt")).toEqual({
+			kind: "remote",
+			session: "alice",
+			path: "file.txt",
+		});
+	});
+});
+
+describe("resolveDirection", () => {
+	test("local source + remote dest = upload", () => {
+		const result = resolveDirection(
+			{ kind: "local", path: "./file.txt" },
+			{ kind: "remote", session: "alice", path: "/tmp/file.txt" },
+		);
+		expect(result).toEqual({
+			direction: "upload",
+			local: "./file.txt",
+			remote: { session: "alice", path: "/tmp/file.txt" },
+		});
+	});
+
+	test("remote source + local dest = download", () => {
+		const result = resolveDirection(
+			{ kind: "remote", session: "alice", path: "/tmp/file.txt" },
+			{ kind: "local", path: "./file.txt" },
+		);
+		expect(result).toEqual({
+			direction: "download",
+			remote: { session: "alice", path: "/tmp/file.txt" },
+			local: "./file.txt",
+		});
+	});
+
+	test("remote-to-remote throws", () => {
+		expect(() =>
+			resolveDirection(
+				{ kind: "remote", session: "alice", path: "/a" },
+				{ kind: "remote", session: "bob", path: "/b" },
+			),
+		).toThrow("Remote-to-remote copy is not supported");
+	});
+
+	test("local-to-local throws", () => {
+		expect(() =>
+			resolveDirection(
+				{ kind: "local", path: "/a" },
+				{ kind: "local", path: "/b" },
+			),
+		).toThrow("Both source and destination are local");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// runCp – upload
+// ---------------------------------------------------------------------------
+
+describe("commands/cp – upload", () => {
+	test("uploads a single file", async () => {
+		const events: string[] = [];
+		const result = await runCp(
+			"./local.txt",
+			"alice:/remote.txt",
+			{},
+			makeBaseDeps({
+				uploadFile: async (_sftp, local, remote) => {
+					events.push(`upload:${local}→${remote}`);
+					return { filesTransferred: 1, bytesTransferred: 42 };
+				},
+			}),
+		);
+
+		expect(result).toEqual({ filesTransferred: 1, bytesTransferred: 42 });
+		expect(events).toContain("upload:./local.txt→/remote.txt");
+	});
+
+	test("uploads a directory with -r", async () => {
+		const events: string[] = [];
+		const result = await runCp(
+			"./mydir",
+			"alice:/remote/mydir",
+			{ recursive: true },
+			makeBaseDeps({
+				localStat: async () => ({ isDirectory: true }),
+				uploadDirectory: async (_sftp, local, remote) => {
+					events.push(`upload-dir:${local}→${remote}`);
+					return { filesTransferred: 5, bytesTransferred: 500 };
+				},
+			}),
+		);
+
+		expect(result).toEqual({ filesTransferred: 5, bytesTransferred: 500 });
+		expect(events).toContain("upload-dir:./mydir→/remote/mydir");
+	});
+
+	test("rejects directory upload without -r", async () => {
+		await expect(
+			runCp(
+				"./mydir",
+				"alice:/remote/mydir",
+				{},
+				makeBaseDeps({
+					localStat: async () => ({ isDirectory: true }),
+				}),
+			),
+		).rejects.toThrow("is a directory. Use -r to copy directories");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// runCp – download
+// ---------------------------------------------------------------------------
+
+describe("commands/cp – download", () => {
+	test("downloads a single file", async () => {
+		const events: string[] = [];
+		const result = await runCp(
+			"alice:/remote/file.txt",
+			"./local.txt",
+			{},
+			makeBaseDeps({
+				remoteStat: async () => ({ isDirectory: false, size: 200 }),
+				downloadFile: async (_sftp, remote, local) => {
+					events.push(`download:${remote}→${local}`);
+					return { filesTransferred: 1, bytesTransferred: 200 };
+				},
+			}),
+		);
+
+		expect(result).toEqual({ filesTransferred: 1, bytesTransferred: 200 });
+		expect(events).toContain("download:/remote/file.txt→./local.txt");
+	});
+
+	test("downloads a directory with -r", async () => {
+		const events: string[] = [];
+		const result = await runCp(
+			"alice:/remote/dir",
+			"./local-dir",
+			{ recursive: true },
+			makeBaseDeps({
+				remoteStat: async () => ({ isDirectory: true, size: 0 }),
+				downloadDirectory: async (_sftp, remote, local) => {
+					events.push(`download-dir:${remote}→${local}`);
+					return { filesTransferred: 10, bytesTransferred: 1024 };
+				},
+			}),
+		);
+
+		expect(result).toEqual({
+			filesTransferred: 10,
+			bytesTransferred: 1024,
+		});
+		expect(events).toContain("download-dir:/remote/dir→./local-dir");
+	});
+
+	test("rejects directory download without -r", async () => {
+		await expect(
+			runCp(
+				"alice:/remote/dir",
+				"./local-dir",
+				{},
+				makeBaseDeps({
+					remoteStat: async () => ({ isDirectory: true, size: 0 }),
+				}),
+			),
+		).rejects.toThrow("is a directory. Use -r to copy directories");
+	});
+
+	test("throws when remote path not found", async () => {
+		await expect(
+			runCp(
+				"alice:/nonexistent",
+				"./local.txt",
+				{},
+				makeBaseDeps({
+					remoteStat: async () => {
+						throw new Error("No such file");
+					},
+				}),
+			),
+		).rejects.toThrow("Remote path '/nonexistent' not found");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// runCp – error handling
+// ---------------------------------------------------------------------------
+
+describe("commands/cp – error handling", () => {
+	test("rejects when session is not running", async () => {
+		await expect(
+			runCp(
+				"./file.txt",
+				"alice:/remote.txt",
+				{},
+				makeBaseDeps({
+					store: {
+						get: async () => makeRunningSession({ status: "stopped" }),
+					},
+				}),
+			),
+		).rejects.toMatchObject({ exitCode: 5 });
+	});
+
+	test("rejects when session is not found", async () => {
+		const { NotFoundError } = await import("@/session/types");
+		await expect(
+			runCp(
+				"./file.txt",
+				"alice:/remote.txt",
+				{},
+				makeBaseDeps({
+					store: {
+						get: async () => {
+							throw new NotFoundError("alice");
+						},
+					},
+				}),
+			),
+		).rejects.toMatchObject({ exitCode: 4 });
+	});
+
+	test("closes SSH client when SFTP transfer throws", async () => {
+		const events: string[] = [];
+		await expect(
+			runCp(
+				"./file.txt",
+				"alice:/remote.txt",
+				{},
+				makeBaseDeps({
+					createSSHClient: () => makeMockSSHClient(events),
+					uploadFile: async () => {
+						throw new Error("transfer failed");
+					},
+				}),
+			),
+		).rejects.toThrow("transfer failed");
+
+		expect(events).toContain("client.connect");
+		expect(events).toContain("client.close");
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `sandctl cp` command for copying files/directories between local machine and sandbox VMs
- Uses SCP-style syntax: `sandctl cp ./file.txt session:/path/` and `sandctl cp session:/path/file.txt ./local/`
- Transfers files via the ssh2 SFTP subsystem, reusing existing SSH auth infrastructure
- Supports recursive directory copy (`-r`), `--json` output, and proper error messages

## Implementation

- Extends `SSHClientLike` and `SSHConnectionLike` interfaces with `sftp()` method and SFTP wrapper types
- New `src/commands/cp.ts` with full dependency injection for testability (follows exec.ts pattern)
- 15 unit tests covering: argument parsing, upload/download, recursive mode, error cases (session not found, not running, missing `-r` flag, remote path not found)

## Test plan

- [x] `npx biome check` passes
- [x] All 218 unit tests pass
- [ ] CI checks: lint, build, test, contract-tests, e2e
- [ ] Manual test: `sandctl cp ./file.txt session:/tmp/` (local → remote)
- [ ] Manual test: `sandctl cp session:/tmp/file.txt ./` (remote → local)
- [ ] Manual test: `sandctl cp -r ./dir session:/tmp/dir` (recursive)
- [ ] Manual test: `sandctl cp --json ./file.txt session:/tmp/` (JSON output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)