### PR TITLE
feat: add Node.js and Claude Code to cloud-init

### DIFF
--- a/src/hetzner/setup.ts
+++ b/src/hetzner/setup.ts
@@ -1,3 +1,13 @@
+export function generatePostSnapshotSSHSetup(): string {
+	return [
+		"mkdir -p /home/agent/.ssh",
+		"cp /root/.ssh/authorized_keys /home/agent/.ssh/authorized_keys",
+		"chown -R agent:agent /home/agent/.ssh",
+		"chmod 700 /home/agent/.ssh",
+		"chmod 600 /home/agent/.ssh/authorized_keys",
+	].join(" && ");
+}
+
 export const DEFAULT_REGION = "ash";
 export const DEFAULT_SERVER_TYPE = "cpx31";
 export const DEFAULT_IMAGE = "ubuntu-24.04";
@@ -59,6 +69,13 @@ runcmd:
   - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
   - apt-get update
   - apt-get install -y gh
+
+  # Install Node.js
+  - curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+  - apt-get install -y nodejs
+
+  # Install Claude Code
+  - npm install -g @anthropic-ai/claude-code
 
   # Clean up
   - apt-get autoremove -y

--- a/tests/unit/hetzner/setup.test.ts
+++ b/tests/unit/hetzner/setup.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	generateCloudInit,
+	generatePostSnapshotSSHSetup,
+} from "@/hetzner/setup";
+
+describe("hetzner/setup", () => {
+	describe("generateCloudInit", () => {
+		test("installs Node.js via NodeSource", () => {
+			const output = generateCloudInit();
+			expect(output).toContain("nodesource.com/setup_22.x");
+			expect(output).toContain("apt-get install -y nodejs");
+		});
+
+		test("installs Claude Code globally", () => {
+			const output = generateCloudInit();
+			expect(output).toContain("npm install -g @anthropic-ai/claude-code");
+		});
+
+		test("creates agent user with docker and sudo groups", () => {
+			const output = generateCloudInit();
+			expect(output).toContain("name: agent");
+			expect(output).toContain("docker");
+			expect(output).toContain("sudo");
+		});
+
+		test("installs Docker Engine", () => {
+			const output = generateCloudInit();
+			expect(output).toContain("docker-ce");
+		});
+
+		test("installs GitHub CLI", () => {
+			const output = generateCloudInit();
+			expect(output).toContain("apt-get install -y gh");
+		});
+	});
+
+	describe("generatePostSnapshotSSHSetup", () => {
+		test("copies SSH keys from root to agent user", () => {
+			const output = generatePostSnapshotSSHSetup();
+			expect(output).toContain(
+				"cp /root/.ssh/authorized_keys /home/agent/.ssh/authorized_keys",
+			);
+		});
+
+		test("sets correct ownership and permissions", () => {
+			const output = generatePostSnapshotSSHSetup();
+			expect(output).toContain("chown -R agent:agent /home/agent/.ssh");
+			expect(output).toContain("chmod 700 /home/agent/.ssh");
+			expect(output).toContain("chmod 600 /home/agent/.ssh/authorized_keys");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Install Node.js 22 LTS (via NodeSource) in the base cloud-init script
- Install Claude Code globally (`npm install -g @anthropic-ai/claude-code`) so every VM has it ready
- Add `generatePostSnapshotSSHSetup()` helper (used by upcoming snapshot caching PR)

## Test plan

- [x] 7 new unit tests for cloud-init content and post-snapshot SSH setup
- [x] All 207 tests pass
- [x] Biome lint clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)