### PR TITLE
feat: add `sandctl status` command for session details

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,134 @@
+import { Command } from "commander";
+import { DateTime } from "luxon";
+import { formatTimeout } from "@/commands/list";
+import {
+	lookupSession,
+	type SessionStoreLike,
+} from "@/commands/shared/session-runtime";
+import { SessionStore } from "@/session/store";
+import { age, type Session, timeoutRemaining } from "@/session/types";
+
+interface Dependencies {
+	store: SessionStoreLike;
+	log: (message: string) => void;
+}
+
+const defaultDependencies: Dependencies = {
+	store: new SessionStore(),
+	log: (message: string) => {
+		console.log(message);
+	},
+};
+
+function formatAge(ms: number): string {
+	const seconds = Math.floor(ms / 1000);
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(minutes / 60);
+	const days = Math.floor(hours / 24);
+
+	if (days > 0) {
+		const remainingHours = hours % 24;
+		return remainingHours > 0 ? `${days}d${remainingHours}h` : `${days}d`;
+	}
+	if (hours > 0) {
+		const remainingMinutes = minutes % 60;
+		return remainingMinutes > 0 ? `${hours}h${remainingMinutes}m` : `${hours}h`;
+	}
+	if (minutes > 0) {
+		return `${minutes}m`;
+	}
+	return `${seconds}s`;
+}
+
+function formatCreatedAt(createdAt: string): string {
+	return DateTime.fromISO(createdAt).toLocal().toFormat("yyyy-MM-dd HH:mm:ss");
+}
+
+export interface StatusResult {
+	id: string;
+	status: string;
+	provider: string;
+	provider_id: string;
+	ip_address: string;
+	region: string;
+	server_type: string;
+	created_at: string;
+	uptime: string;
+	timeout: string | null;
+	timeout_remaining: string;
+	failure_reason: string | null;
+}
+
+function buildResult(session: Session): StatusResult {
+	const remaining = timeoutRemaining(session);
+	return {
+		id: session.id,
+		status: session.status,
+		provider: session.provider,
+		provider_id: session.provider_id,
+		ip_address: session.ip_address || "-",
+		region: session.region ?? "-",
+		server_type: session.server_type ?? "-",
+		created_at: session.created_at,
+		uptime: formatAge(age(session)),
+		timeout: session.timeout ?? null,
+		timeout_remaining: formatTimeout(remaining),
+		failure_reason: session.failure_reason ?? null,
+	};
+}
+
+export async function runStatus(
+	name: string,
+	deps: Partial<Dependencies> = {},
+): Promise<StatusResult> {
+	const dependencies = {
+		...defaultDependencies,
+		...deps,
+	};
+
+	const session = await lookupSession(name, dependencies.store);
+	return buildResult(session);
+}
+
+function outputTable(result: StatusResult, log: (msg: string) => void): void {
+	const rows: Array<[string, string]> = [
+		["ID", result.id],
+		["Status", result.status],
+		["Provider", result.provider],
+		["Provider ID", result.provider_id],
+		["IP Address", result.ip_address],
+		["Region", result.region],
+		["Server Type", result.server_type],
+		["Created", formatCreatedAt(result.created_at)],
+		["Uptime", result.uptime],
+		["Timeout", result.timeout ?? "-"],
+		["Remaining", result.timeout_remaining],
+	];
+
+	if (result.failure_reason) {
+		rows.push(["Failure Reason", result.failure_reason]);
+	}
+
+	const labelWidth = Math.max(...rows.map(([label]) => label.length)) + 1;
+	for (const [label, value] of rows) {
+		log(`${`${label}:`.padEnd(labelWidth + 1)} ${value}`);
+	}
+}
+
+export function registerStatusCommand(): Command {
+	return new Command("status")
+		.description("Show detailed information about a session")
+		.argument("<name>")
+		.action(async (name: string, _options: unknown, command: Command) => {
+			const globals = command.optsWithGlobals() as {
+				config?: string;
+				json?: boolean;
+			};
+			const result = await runStatus(name);
+			if (globals.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+			outputTable(result, console.log);
+		});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { registerInitCommand } from "@/commands/init";
 import { registerListCommand } from "@/commands/list";
 import { registerNewCommand } from "@/commands/new";
 import { registerOpenCommand } from "@/commands/open";
+import { registerStatusCommand } from "@/commands/status";
 import { registerTemplateCommand } from "@/commands/template";
 import { registerVersionCommand } from "@/commands/version";
 
@@ -25,6 +26,7 @@ program.addCommand(registerListCommand());
 program.addCommand(registerExecCommand());
 program.addCommand(registerConsoleCommand());
 program.addCommand(registerOpenCommand());
+program.addCommand(registerStatusCommand());
 program.addCommand(registerDestroyCommand());
 program.addCommand(registerExtendCommand());
 program.addCommand(registerTemplateCommand());

--- a/tests/unit/commands/status.test.ts
+++ b/tests/unit/commands/status.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+
+import { runStatus } from "@/commands/status";
+import { makeRunningSession } from "../../support/fixtures";
+
+describe("commands/status", () => {
+	test("returns status result for a running session", async () => {
+		const result = await runStatus("alice", {
+			store: {
+				get: async () => makeRunningSession(),
+			},
+		});
+
+		expect(result.id).toBe("alice");
+		expect(result.status).toBe("running");
+		expect(result.provider).toBe("hetzner");
+		expect(result.provider_id).toBe("vm-123");
+		expect(result.ip_address).toBe("203.0.113.10");
+		expect(result.failure_reason).toBeNull();
+	});
+
+	test("normalizes session name", async () => {
+		let lookedUp = "";
+
+		await runStatus("Alice", {
+			store: {
+				get: async (id: string) => {
+					lookedUp = id;
+					return makeRunningSession();
+				},
+			},
+		});
+
+		expect(lookedUp).toBe("alice");
+	});
+
+	test("rejects with exit code 4 when session not found", async () => {
+		const { NotFoundError } = await import("@/session/types");
+
+		await expect(
+			runStatus("missing", {
+				store: {
+					get: async () => {
+						throw new NotFoundError("missing");
+					},
+				},
+			}),
+		).rejects.toMatchObject({
+			exitCode: 4,
+		});
+	});
+
+	test("includes failure reason when present", async () => {
+		const result = await runStatus("alice", {
+			store: {
+				get: async () =>
+					makeRunningSession({
+						status: "failed",
+						failure_reason: "cloud-init timeout",
+					}),
+			},
+		});
+
+		expect(result.status).toBe("failed");
+		expect(result.failure_reason).toBe("cloud-init timeout");
+	});
+
+	test("shows timeout remaining when timeout is set", async () => {
+		const result = await runStatus("alice", {
+			store: {
+				get: async () =>
+					makeRunningSession({
+						timeout: "2h0m0s",
+						created_at: new Date().toISOString(),
+					}),
+			},
+		});
+
+		expect(result.timeout).toBe("2h0m0s");
+		expect(result.timeout_remaining).toContain("remaining");
+	});
+
+	test("shows dash for missing optional fields", async () => {
+		const result = await runStatus("alice", {
+			store: {
+				get: async () =>
+					makeRunningSession({
+						ip_address: "",
+						region: undefined,
+						server_type: undefined,
+					}),
+			},
+		});
+
+		expect(result.ip_address).toBe("-");
+		expect(result.region).toBe("-");
+		expect(result.server_type).toBe("-");
+	});
+
+	test("computes uptime from created_at", async () => {
+		const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+		const result = await runStatus("alice", {
+			store: {
+				get: async () => makeRunningSession({ created_at: oneHourAgo }),
+			},
+		});
+
+		expect(result.uptime).toBe("1h");
+	});
+});


### PR DESCRIPTION
## Summary

- New `sandctl status <session>` command showing detailed session info
- Displays: ID, status, provider, provider ID, IP address, region, server type, created timestamp, uptime, timeout + remaining, failure reason
- `--json` outputs all fields as structured JSON
- Uses `lookupSession` from shared session-runtime for consistent name resolution

### Example output

```
ID:             alice
Status:         running
Provider:       hetzner
Provider ID:    vm-123
IP Address:     203.0.113.10
Region:         ash
Server Type:    cpx31
Created:        2026-03-16 15:30:00
Uptime:         2h15m
Timeout:        4h0m0s
Remaining:      1h45m remaining
```

## Test plan

- [x] 7 unit tests covering lookup, normalization, error handling, computed fields
- [x] All tests pass
- [x] Biome lint clean
- [x] Build succeeds
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)