### PR TITLE
feat: add `sandctl reap` command to destroy expired sessions

### DIFF
--- a/src/commands/reap.ts
+++ b/src/commands/reap.ts
@@ -1,0 +1,234 @@
+import { Command } from "commander";
+
+import {
+	type Config,
+	getProviderConfig,
+	load,
+	type ProviderConfig,
+} from "@/config/config";
+import { getProvider } from "@/provider";
+import { get as getProviderFromRegistry } from "@/provider/registry";
+import { SessionStore } from "@/session/store";
+import {
+	age,
+	Duration,
+	isActive,
+	type Session,
+	timeoutRemaining,
+} from "@/session/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReapResult {
+	id: string;
+	provider: string;
+	age: string;
+	timeout: string;
+	past_expiry: string;
+	destroyed: boolean;
+	error?: string;
+}
+
+interface Dependencies {
+	loadConfig: (configPath?: string) => Promise<Config>;
+	resolveProvider: (
+		name: string,
+		config: ProviderConfig,
+	) => ReturnType<typeof getProviderFromRegistry>;
+	resolveLegacyProvider: typeof getProvider;
+	store: SessionStore;
+	log: (message: string) => void;
+	warn: (message: string) => void;
+}
+
+const defaultDependencies: Dependencies = {
+	loadConfig: load,
+	resolveProvider: getProviderFromRegistry,
+	resolveLegacyProvider: getProvider,
+	store: new SessionStore(),
+	log: (message: string) => {
+		console.log(message);
+	},
+	warn: (message: string) => {
+		console.warn(message);
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDuration(ms: number): string {
+	const seconds = Math.floor(ms / 1000);
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(minutes / 60);
+	const days = Math.floor(hours / 24);
+
+	if (days > 0) {
+		const remainingHours = hours % 24;
+		return remainingHours > 0 ? `${days}d${remainingHours}h` : `${days}d`;
+	}
+	if (hours > 0) {
+		const remainingMinutes = minutes % 60;
+		return remainingMinutes > 0 ? `${hours}h${remainingMinutes}m` : `${hours}h`;
+	}
+	if (minutes > 0) {
+		return `${minutes}m`;
+	}
+	return `${seconds}s`;
+}
+
+function findExpiredSessions(sessions: Session[]): Session[] {
+	return sessions.filter((session) => {
+		if (!isActive(session)) {
+			return false;
+		}
+		if (!session.timeout) {
+			return false;
+		}
+		const remaining = timeoutRemaining(session);
+		return remaining !== null && remaining <= 0;
+	});
+}
+
+async function destroySession(
+	session: Session,
+	deps: Dependencies,
+	configPath?: string,
+): Promise<void> {
+	if (!session.provider_id) {
+		await deps.store.remove(session.id);
+		return;
+	}
+
+	let deletionAttempted = false;
+	let deleteError: unknown;
+
+	try {
+		const config = await deps.loadConfig(configPath);
+		const providerConfig = getProviderConfig(config, session.provider);
+		if (providerConfig) {
+			const provider = deps.resolveProvider(session.provider, providerConfig);
+			await provider.delete(session.provider_id);
+			deletionAttempted = true;
+		}
+	} catch (error) {
+		deleteError = error;
+	}
+
+	if (!deletionAttempted) {
+		const legacyProvider = deps.resolveLegacyProvider(session.provider);
+		if (legacyProvider) {
+			try {
+				await legacyProvider.deleteVM(session.provider_id);
+				deletionAttempted = true;
+			} catch (error) {
+				deleteError = error;
+			}
+		}
+	}
+
+	if (!deletionAttempted) {
+		const details = deleteError
+			? deleteError instanceof Error
+				? deleteError.message
+				: String(deleteError)
+			: `provider '${session.provider}' is not configured`;
+		throw new Error(
+			`Failed to delete provider VM '${session.provider_id}': ${details}`,
+		);
+	}
+
+	await deps.store.remove(session.id);
+}
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+export async function runReap(
+	options: { dryRun: boolean },
+	deps: Partial<Dependencies> = {},
+	configPath?: string,
+): Promise<ReapResult[]> {
+	const dependencies = {
+		...defaultDependencies,
+		...deps,
+	};
+
+	const sessions = await dependencies.store.listActive();
+	const expired = findExpiredSessions(sessions);
+
+	if (expired.length === 0) {
+		dependencies.log("No expired sessions found.");
+		return [];
+	}
+
+	const results: ReapResult[] = [];
+
+	for (const session of expired) {
+		const sessionAge = age(session);
+		const timeoutMs = Duration.parse(session.timeout as string).milliseconds;
+		const pastExpiry = sessionAge - timeoutMs;
+
+		const result: ReapResult = {
+			id: session.id,
+			provider: session.provider,
+			age: formatDuration(sessionAge),
+			timeout: session.timeout as string,
+			past_expiry: formatDuration(pastExpiry),
+			destroyed: false,
+		};
+
+		if (options.dryRun) {
+			dependencies.log(
+				`[dry-run] Would reap '${session.id}' (age: ${result.age}, timeout: ${result.timeout}, expired ${result.past_expiry} ago)`,
+			);
+			results.push(result);
+			continue;
+		}
+
+		try {
+			await destroySession(session, dependencies, configPath);
+			result.destroyed = true;
+			dependencies.log(
+				`Reaped '${session.id}' (age: ${result.age}, timeout: ${result.timeout}, expired ${result.past_expiry} ago)`,
+			);
+		} catch (error) {
+			result.error = error instanceof Error ? error.message : String(error);
+			dependencies.warn(
+				`[warn] Failed to reap '${session.id}': ${result.error}`,
+			);
+		}
+
+		results.push(result);
+	}
+
+	return results;
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerReapCommand(): Command {
+	return new Command("reap")
+		.description("Destroy sessions with expired timeouts")
+		.option(
+			"-n, --dry-run",
+			"Preview what would be reaped without destroying",
+			false,
+		)
+		.action(async (options: { dryRun: boolean }, command) => {
+			const globals = command.optsWithGlobals() as {
+				config?: string;
+				json?: boolean;
+			};
+			const results = await runReap(options, undefined, globals.config);
+			if (globals.json) {
+				console.log(JSON.stringify(results, null, 2));
+			}
+		});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { registerListCommand } from "@/commands/list";
 import { registerLogsCommand } from "@/commands/logs";
 import { registerNewCommand } from "@/commands/new";
 import { registerOpenCommand } from "@/commands/open";
+import { registerReapCommand } from "@/commands/reap";
 import { registerStatusCommand } from "@/commands/status";
 import { registerTemplateCommand } from "@/commands/template";
 import { registerVersionCommand } from "@/commands/version";
@@ -30,6 +31,7 @@ program.addCommand(registerConsoleCommand());
 program.addCommand(registerOpenCommand());
 program.addCommand(registerStatusCommand());
 program.addCommand(registerDestroyCommand());
+program.addCommand(registerReapCommand());
 program.addCommand(registerExtendCommand());
 program.addCommand(registerTemplateCommand());
 

--- a/tests/unit/commands/reap.test.ts
+++ b/tests/unit/commands/reap.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runReap } from "@/commands/reap";
+import type { Provider, SSHKeyManager } from "@/provider/interface";
+import { SessionStore } from "@/session/store";
+import type { Session } from "@/session/types";
+import { baseProviderConfig } from "../../support/fixtures";
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+	return {
+		id: "alice",
+		status: "running",
+		provider: "hetzner",
+		provider_id: "vm-123",
+		ip_address: "203.0.113.10",
+		created_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2h ago
+		timeout: "1h0m0s",
+		...overrides,
+	};
+}
+
+function makeProvider(
+	deleteFn: (id: string) => Promise<void> = async () => {},
+): Provider & SSHKeyManager {
+	return {
+		name: () => "hetzner",
+		create: async () => {
+			throw new Error("not implemented");
+		},
+		get: async () => {
+			throw new Error("not implemented");
+		},
+		delete: deleteFn,
+		list: async () => [],
+		waitReady: async () => {
+			throw new Error("not implemented");
+		},
+		ensureSSHKey: async () => "1",
+	};
+}
+
+describe("commands/reap", () => {
+	let store: SessionStore;
+	let logSpy: ReturnType<typeof spyOn>;
+	let warnSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(async () => {
+		const dir = await mkdtemp(join(tmpdir(), "sandctl-reap-test-"));
+		store = new SessionStore(join(dir, "sessions.json"));
+		logSpy = spyOn(console, "log").mockImplementation(() => {});
+		warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+		warnSpy.mockRestore();
+	});
+
+	test("returns empty array when no sessions exist", async () => {
+		const results = await runReap({ dryRun: false }, { store });
+		expect(results).toEqual([]);
+	});
+
+	test("ignores sessions without a timeout", async () => {
+		await store.add(makeSession({ timeout: undefined }));
+		const results = await runReap({ dryRun: false }, { store });
+		expect(results).toEqual([]);
+	});
+
+	test("ignores sessions whose timeout has not expired", async () => {
+		await store.add(
+			makeSession({
+				created_at: new Date().toISOString(), // just created
+				timeout: "1h0m0s",
+			}),
+		);
+		const results = await runReap({ dryRun: false }, { store });
+		expect(results).toEqual([]);
+	});
+
+	test("ignores stopped sessions even if expired", async () => {
+		await store.add(makeSession({ status: "stopped" }));
+		const results = await runReap({ dryRun: false }, { store });
+		expect(results).toEqual([]);
+	});
+
+	test("ignores failed sessions even if expired", async () => {
+		await store.add(makeSession({ status: "failed" }));
+		const results = await runReap({ dryRun: false }, { store });
+		expect(results).toEqual([]);
+	});
+
+	test("reaps expired active session", async () => {
+		await store.add(makeSession());
+		const deleted: string[] = [];
+		const provider = makeProvider(async (id) => {
+			deleted.push(id);
+		});
+
+		const results = await runReap(
+			{ dryRun: false },
+			{
+				store,
+				loadConfig: async () => baseProviderConfig,
+				resolveProvider: () => provider,
+			},
+		);
+
+		expect(results).toHaveLength(1);
+		expect(results[0].id).toBe("alice");
+		expect(results[0].destroyed).toBe(true);
+		expect(results[0].error).toBeUndefined();
+		expect(deleted).toEqual(["vm-123"]);
+		await expect(store.get("alice")).rejects.toBeDefined();
+	});
+
+	test("reaps provisioning sessions with expired timeout", async () => {
+		await store.add(makeSession({ status: "provisioning" }));
+		const provider = makeProvider();
+
+		const results = await runReap(
+			{ dryRun: false },
+			{
+				store,
+				loadConfig: async () => baseProviderConfig,
+				resolveProvider: () => provider,
+			},
+		);
+
+		expect(results).toHaveLength(1);
+		expect(results[0].destroyed).toBe(true);
+	});
+
+	test("dry-run does not destroy sessions", async () => {
+		await store.add(makeSession());
+		const deleted: string[] = [];
+		const provider = makeProvider(async (id) => {
+			deleted.push(id);
+		});
+
+		const results = await runReap(
+			{ dryRun: true },
+			{
+				store,
+				loadConfig: async () => baseProviderConfig,
+				resolveProvider: () => provider,
+			},
+		);
+
+		expect(results).toHaveLength(1);
+		expect(results[0].id).toBe("alice");
+		expect(results[0].destroyed).toBe(false);
+		expect(results[0].error).toBeUndefined();
+		expect(deleted).toEqual([]);
+		// Session should still exist
+		expect(await store.get("alice")).toMatchObject({ id: "alice" });
+	});
+
+	test("continues reaping other sessions when one fails", async () => {
+		await store.add(makeSession({ id: "alice", provider_id: "vm-fail" }));
+		await store.add(makeSession({ id: "bob", provider_id: "vm-ok" }));
+
+		const provider = makeProvider(async (id) => {
+			if (id === "vm-fail") {
+				throw new Error("cloud API error");
+			}
+		});
+
+		const results = await runReap(
+			{ dryRun: false },
+			{
+				store,
+				loadConfig: async () => baseProviderConfig,
+				resolveProvider: () => provider,
+			},
+		);
+
+		expect(results).toHaveLength(2);
+
+		const aliceResult = results.find((r) => r.id === "alice");
+		const bobResult = results.find((r) => r.id === "bob");
+
+		expect(aliceResult?.destroyed).toBe(false);
+		expect(aliceResult?.error).toBeDefined();
+
+		expect(bobResult?.destroyed).toBe(true);
+		expect(bobResult?.error).toBeUndefined();
+
+		// alice should still exist, bob should be removed
+		expect(await store.get("alice")).toMatchObject({ id: "alice" });
+		await expect(store.get("bob")).rejects.toBeDefined();
+	});
+
+	test("result includes age, timeout, and past_expiry fields", async () => {
+		await store.add(makeSession());
+		const provider = makeProvider();
+
+		const results = await runReap(
+			{ dryRun: true },
+			{
+				store,
+				loadConfig: async () => baseProviderConfig,
+				resolveProvider: () => provider,
+			},
+		);
+
+		expect(results).toHaveLength(1);
+		expect(results[0].age).toMatch(/^\d+[dhms]/);
+		expect(results[0].timeout).toBe("1h0m0s");
+		expect(results[0].past_expiry).toMatch(/^\d+[dhms]/);
+		expect(results[0].provider).toBe("hetzner");
+	});
+
+	test("reaps legacy sessions without provider_id using force removal", async () => {
+		await store.add(
+			makeSession({
+				id: "legacy",
+				provider: "",
+				provider_id: "",
+			}),
+		);
+
+		const results = await runReap({ dryRun: false }, { store });
+
+		expect(results).toHaveLength(1);
+		expect(results[0].id).toBe("legacy");
+		expect(results[0].destroyed).toBe(true);
+		await expect(store.get("legacy")).rejects.toBeDefined();
+	});
+
+	test("reaps multiple expired sessions", async () => {
+		await store.add(makeSession({ id: "alice", provider_id: "vm-1" }));
+		await store.add(makeSession({ id: "bob", provider_id: "vm-2" }));
+		await store.add(
+			makeSession({
+				id: "carol",
+				created_at: new Date().toISOString(),
+				timeout: "1h0m0s",
+			}),
+		);
+
+		const provider = makeProvider();
+
+		const results = await runReap(
+			{ dryRun: false },
+			{
+				store,
+				loadConfig: async () => baseProviderConfig,
+				resolveProvider: () => provider,
+			},
+		);
+
+		// alice and bob are expired, carol is not
+		expect(results).toHaveLength(2);
+		expect(results.map((r) => r.id).sort()).toEqual(["alice", "bob"]);
+	});
+
+	test("custom log and warn functions are used", async () => {
+		await store.add(makeSession());
+		const logs: string[] = [];
+		const warns: string[] = [];
+		const provider = makeProvider();
+
+		await runReap(
+			{ dryRun: false },
+			{
+				store,
+				loadConfig: async () => baseProviderConfig,
+				resolveProvider: () => provider,
+				log: (msg) => logs.push(msg),
+				warn: (msg) => warns.push(msg),
+			},
+		);
+
+		expect(logs).toHaveLength(1);
+		expect(logs[0]).toContain("Reaped 'alice'");
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a new `sandctl reap` command that finds all active sessions with expired timeouts and destroys them
- Designed for automation/cron usage — no confirmation prompts, graceful per-session error handling
- Supports `--dry-run` / `-n` to preview what would be reaped, and `--json` for machine-readable output

## Details

Sessions with a `timeout` field that have been running longer than their timeout are identified and destroyed using the existing provider deletion logic (same as `sandctl destroy`). Each expired session reports its name, age, timeout duration, and how long past expiry it is.

Key design decisions:
• No confirmation prompt — intended for unattended/cron use
• Per-session error isolation — if one session fails to destroy, the others still get reaped
• Legacy sessions (no `provider_id`) are cleaned up from local state
• Reuses the same provider deletion flow as `destroy.ts`

## Test plan

- [x] Unit tests cover: no sessions, no timeout, unexpired, stopped/failed sessions, successful reap, dry-run, error isolation, multiple sessions, legacy sessions, custom log/warn
- [x] `npx biome check` passes (lint + format)
- [x] `bun run build` succeeds
- [x] All 244 unit tests pass
- [x] All e2e/contract tests pass (12 pass, 1 skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)