### PR TITLE
feat: add mosh to base cloud-init

### DIFF
--- a/src/hetzner/setup.ts
+++ b/src/hetzner/setup.ts
@@ -24,6 +24,7 @@ packages:
   - wget
   - jq
   - htop
+  - mosh
   - tmux
   - vim
 

--- a/tests/unit/hetzner/setup.test.ts
+++ b/tests/unit/hetzner/setup.test.ts
@@ -34,6 +34,11 @@ describe("hetzner/setup", () => {
 			const output = generateCloudInit();
 			expect(output).toContain("apt-get install -y gh");
 		});
+
+		test("installs mosh", () => {
+			const output = generateCloudInit();
+			expect(output).toContain("- mosh");
+		});
 	});
 
 	describe("generatePostSnapshotSSHSetup", () => {


### PR DESCRIPTION
## Summary
• Adds `mosh` to the cloud-init packages list so VMs come with it pre-installed
• Adds test verifying mosh is included in the generated cloud-init output

## Test plan
- [x] All 258 unit tests pass
- [x] Build succeeds
- [x] Biome lint clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)