### PR TITLE
feat: add hooks system with new-console-session hook

### DIFF
--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -16,6 +16,7 @@ import {
 	type SSHClientOptions,
 } from "@/ssh/client";
 import { type ConsoleOptions, openConsole } from "@/ssh/console";
+import { type ExecResult, exec } from "@/ssh/exec";
 
 export { CommandExitError };
 
@@ -23,6 +24,10 @@ interface Dependencies {
 	store: SessionStoreLike;
 	loadConfig: (configPath?: string) => Promise<Config>;
 	createSSHClient: (options: SSHClientOptions) => SSHRuntimeClient;
+	runRemoteCommand: (
+		client: SSHClientLike,
+		command: string,
+	) => Promise<ExecResult>;
 	openRemoteConsole: (
 		client: SSHClientLike,
 		options?: ConsoleOptions,
@@ -33,6 +38,7 @@ const defaultDependencies: Dependencies = {
 	store: new SessionStore(),
 	loadConfig: load,
 	createSSHClient: (options) => new SSHClient(options),
+	runRemoteCommand: exec,
 	openRemoteConsole: openConsole,
 };
 
@@ -55,6 +61,15 @@ export async function runConsole(
 	);
 
 	await withSSHClient(client, async (c) => {
+		const hookCommand = config.hooks?.["new-console-session"];
+		if (hookCommand) {
+			try {
+				await dependencies.runRemoteCommand(c, hookCommand);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				console.warn(`Warning: new-console-session hook failed: ${message}`);
+			}
+		}
 		await dependencies.openRemoteConsole(c, {
 			initialCommands: config.post_ssh_commands,
 		});

--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -64,7 +64,15 @@ export async function runConsole(
 		const hookCommand = config.hooks?.["new-console-session"];
 		if (hookCommand) {
 			try {
-				await dependencies.runRemoteCommand(c, hookCommand);
+				const result = await dependencies.runRemoteCommand(c, hookCommand);
+				if (result.stderr) {
+					console.error(result.stderr);
+				}
+				if (result.exitCode !== 0) {
+					console.warn(
+						`Warning: new-console-session hook exited with code ${result.exitCode}`,
+					);
+				}
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				console.warn(`Warning: new-console-session hook failed: ${message}`);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -33,6 +33,9 @@ export interface Config {
 	claude_config_path?: string;
 	claude_oauth_token?: string;
 	post_ssh_commands?: string[];
+	hooks?: {
+		"new-console-session"?: string;
+	};
 }
 
 export class NotFoundError extends Error {

--- a/tests/unit/commands/console.test.ts
+++ b/tests/unit/commands/console.test.ts
@@ -58,6 +58,102 @@ describe("commands/console", () => {
 		expect(events).toContain("client.close");
 	});
 
+	test("runs new-console-session hook before opening console", async () => {
+		const events: string[] = [];
+
+		await runConsole("alice", {
+			store: {
+				get: async () => makeRunningSession(),
+			},
+			loadConfig: async () => ({
+				...agentModeConfig,
+				hooks: { "new-console-session": "setup.sh" },
+			}),
+			createSSHClient: () => ({
+				connect: async () => {},
+				close: async () => {},
+				exec: async () => {
+					throw new Error("not used");
+				},
+				shell: async () => {
+					throw new Error("not used");
+				},
+			}),
+			runRemoteCommand: async (_client, command) => {
+				events.push(`hook:${command}`);
+				return { stdout: "", stderr: "", exitCode: 0 };
+			},
+			openRemoteConsole: async () => {
+				events.push("console.open");
+			},
+		});
+
+		expect(events).toEqual(["hook:setup.sh", "console.open"]);
+	});
+
+	test("opens console normally when no hook configured", async () => {
+		const events: string[] = [];
+
+		await runConsole("alice", {
+			store: {
+				get: async () => makeRunningSession(),
+			},
+			loadConfig: async () => agentModeConfig,
+			createSSHClient: () => ({
+				connect: async () => {},
+				close: async () => {},
+				exec: async () => {
+					throw new Error("not used");
+				},
+				shell: async () => {
+					throw new Error("not used");
+				},
+			}),
+			runRemoteCommand: async () => {
+				events.push("hook.run");
+				return { stdout: "", stderr: "", exitCode: 0 };
+			},
+			openRemoteConsole: async () => {
+				events.push("console.open");
+			},
+		});
+
+		expect(events).toEqual(["console.open"]);
+	});
+
+	test("hook failure does not prevent console from opening", async () => {
+		const events: string[] = [];
+
+		await runConsole("alice", {
+			store: {
+				get: async () => makeRunningSession(),
+			},
+			loadConfig: async () => ({
+				...agentModeConfig,
+				hooks: { "new-console-session": "bad-script.sh" },
+			}),
+			createSSHClient: () => ({
+				connect: async () => {},
+				close: async () => {},
+				exec: async () => {
+					throw new Error("not used");
+				},
+				shell: async () => {
+					throw new Error("not used");
+				},
+			}),
+			runRemoteCommand: async () => {
+				events.push("hook.failed");
+				throw new Error("hook exploded");
+			},
+			openRemoteConsole: async () => {
+				events.push("console.open");
+			},
+		});
+
+		expect(events).toEqual(["hook.failed", "console.open"]);
+	});
+
 	test("closes SSH client when openRemoteConsole throws", async () => {
 		const events: string[] = [];
 


### PR DESCRIPTION
## Summary
• Adds a `hooks` config section with a `new-console-session` hook
• The hook runs a command via SSH `exec` *before* the interactive console opens
• Complements the existing `post_ssh_commands` (which writes into the shell stream) — hooks run as separate exec commands that must complete before the console starts
• Hook failures are caught and logged as warnings, never blocking the console

Example config:
```yaml
hooks:
  new-console-session: "tmux new-session -d -s dev && tmux send-keys 'claude --dangerously-skip-permissions' Enter"
```

## Test plan
- [x] All 276 unit tests pass
- [x] 3 new tests: hook runs before console, no hook = no execution, hook failure doesn't block console
- [x] Build succeeds
- [x] Biome lint clean
- [ ] CI checks pass

Replaces #81 (which had merge conflicts with upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)