### PR TITLE
feat: automatic DNS record management via Cloudflare

### DIFF
--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -1,0 +1,99 @@
+const BASE_URL = "https://api.cloudflare.com/client/v4";
+
+export interface DNSRecord {
+	id: string;
+	type: string;
+	name: string;
+	content: string;
+	ttl: number;
+	proxied: boolean;
+}
+
+interface CloudflareResponse<T> {
+	success: boolean;
+	errors: Array<{ code: number; message: string }>;
+	result: T;
+}
+
+export class CloudflareClient {
+	constructor(
+		private readonly token: string,
+		private readonly zoneId: string,
+		private readonly baseURL = BASE_URL,
+	) {}
+
+	async createDNSRecord(
+		name: string,
+		ip: string,
+		ttl = 60,
+	): Promise<DNSRecord> {
+		const response = await this.request<DNSRecord>(
+			`/zones/${this.zoneId}/dns_records`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "A",
+					name,
+					content: ip,
+					ttl,
+					proxied: false,
+				}),
+			},
+		);
+		return response;
+	}
+
+	async deleteDNSRecord(recordId: string): Promise<void> {
+		await this.request<{ id: string }>(
+			`/zones/${this.zoneId}/dns_records/${recordId}`,
+			{ method: "DELETE" },
+		);
+	}
+
+	async listDNSRecords(name?: string): Promise<DNSRecord[]> {
+		const query: Record<string, string> = { type: "A" };
+		if (name) {
+			query.name = name;
+		}
+		const response = await this.request<DNSRecord[]>(
+			`/zones/${this.zoneId}/dns_records`,
+			{ query },
+		);
+		return response;
+	}
+
+	private async request<T>(
+		pathname: string,
+		options?: {
+			method?: string;
+			body?: string;
+			query?: Record<string, string>;
+		},
+	): Promise<T> {
+		const method = options?.method ?? "GET";
+		const url = new URL(`${this.baseURL}${pathname}`);
+		for (const [key, value] of Object.entries(options?.query ?? {})) {
+			url.searchParams.set(key, value);
+		}
+
+		const response = await fetch(url, {
+			method,
+			headers: {
+				Authorization: `Bearer ${this.token}`,
+				"Content-Type": "application/json",
+			},
+			body: options?.body,
+		});
+
+		const body = (await response.json()) as CloudflareResponse<T>;
+
+		if (!response.ok || !body.success) {
+			const message =
+				body.errors?.map((e) => e.message).join(", ") ??
+				`${response.status} ${response.statusText}`;
+			throw new Error(`Cloudflare API error: ${message}`);
+		}
+
+		return body.result;
+	}
+}

--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -7,6 +7,7 @@ import {
 	load,
 	type ProviderConfig,
 } from "@/config/config";
+import { createDNSManager } from "@/dns/manager";
 import { getProvider } from "@/provider";
 import { get as getProviderFromRegistry } from "@/provider/registry";
 import { normalizeName, validateID } from "@/session/id";
@@ -137,6 +138,17 @@ export async function runDestroy(
 		throw new Error(
 			`Failed to delete provider VM '${session.provider_id}': ${details}`,
 		);
+	}
+
+	// Delete DNS record (best-effort)
+	try {
+		const config = await dependencies.loadConfig(configPath);
+		const dns = createDNSManager(config);
+		if (dns) {
+			await dns.deleteRecord(session.id);
+		}
+	} catch {
+		// DNS cleanup is best-effort — don't block session destruction
 	}
 
 	await store.remove(session.id);

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -19,6 +19,7 @@ import {
 	load,
 	type ProviderConfig,
 } from "@/config/config";
+import { createDNSManager, type DNSManager } from "@/dns/manager";
 import type { HetznerImage } from "@/hetzner/client";
 import { HetznerProvider } from "@/hetzner/provider";
 import {
@@ -143,6 +144,7 @@ interface Dependencies {
 		host: string,
 		deps: Pick<Dependencies, "createSSHClient">,
 	) => Promise<void>;
+	createDNSManager: (config: Config) => DNSManager | null;
 	now: () => Date;
 	warn: (message: string) => void;
 	log: (message: string) => void;
@@ -163,6 +165,7 @@ const defaultDependencies: Dependencies = {
 	cleanupSnapshots: cleanupOldSnapshots,
 	runSSHSetup: defaultRunSSHSetup,
 	setupClaudeConfig: setupClaudeConfigViaSSH,
+	createDNSManager,
 	now: () => new Date(),
 	warn: (message: string) => {
 		console.warn(message);
@@ -631,6 +634,22 @@ export async function runNew(
 			region: readyVM.region,
 			server_type: readyVM.serverType,
 		});
+
+		// Create DNS record (best-effort)
+		if (readyVM.ipAddress) {
+			try {
+				const dns = dependencies.createDNSManager(config);
+				if (dns) {
+					dependencies.log("Creating DNS record...");
+					await dns.createRecord(sessionID, readyVM.ipAddress);
+					dependencies.log(`DNS record created: ${dns.fqdn(sessionID)}`);
+				}
+			} catch (error) {
+				dependencies.warn(
+					`[warn] DNS record creation failed: ${messageFromError(error)}`,
+				);
+			}
+		}
 
 		const session: Session = {
 			id: sessionID,

--- a/src/commands/rename.ts
+++ b/src/commands/rename.ts
@@ -6,6 +6,7 @@ import {
 	load,
 	type ProviderConfig,
 } from "@/config/config";
+import { createDNSManager } from "@/dns/manager";
 import { get as getProviderFromRegistry } from "@/provider/registry";
 import { normalizeName, validateID } from "@/session/id";
 import { SessionStore } from "@/session/store";
@@ -25,6 +26,7 @@ interface SessionStoreLike {
 		id: string;
 		provider: string;
 		provider_id: string;
+		ip_address: string;
 	}>;
 	rename: (oldId: string, newId: string) => Promise<void>;
 }
@@ -109,6 +111,23 @@ export async function runRename(
 	}
 
 	await dependencies.store.rename(normalizedOld, normalizedNew);
+
+	// Update DNS record (best-effort)
+	if (session.ip_address) {
+		try {
+			const config = await dependencies.loadConfig(configPath);
+			const dns = createDNSManager(config);
+			if (dns) {
+				await dns.updateRecord(
+					normalizedOld,
+					normalizedNew,
+					session.ip_address,
+				);
+			}
+		} catch {
+			// DNS update is best-effort — local rename still proceeds
+		}
+	}
 
 	if (!options.silent) {
 		console.log(`Renamed session '${normalizedOld}' to '${normalizedNew}'.`);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -17,6 +17,13 @@ export interface ProviderConfig {
 	ssh_key_id?: number;
 }
 
+export interface DNSConfig {
+	provider?: string;
+	domain?: string;
+	cloudflare_api_token?: string;
+	cloudflare_zone_id?: string;
+}
+
 export interface Config {
 	default_provider?: string;
 	ssh_key_source?: "file" | "agent";
@@ -24,6 +31,7 @@ export interface Config {
 	ssh_public_key_inline?: string;
 	ssh_key_fingerprint?: string;
 	providers?: Record<string, ProviderConfig>;
+	dns?: DNSConfig;
 	sprites_token?: string;
 	opencode_zen_key?: string;
 	git_config_path?: string;
@@ -281,4 +289,12 @@ export function hasClaudeOAuthToken(config: Config): boolean {
 
 export function hasGitHubToken(config: Config): boolean {
 	return Boolean(config.github_token);
+}
+
+export function hasDNSConfig(config: Config): boolean {
+	return Boolean(
+		config.dns?.cloudflare_api_token &&
+			config.dns?.cloudflare_zone_id &&
+			config.dns?.domain,
+	);
 }

--- a/src/dns/manager.ts
+++ b/src/dns/manager.ts
@@ -1,0 +1,61 @@
+import { CloudflareClient } from "@/cloudflare/client";
+import type { Config } from "@/config/config";
+
+export interface DNSManager {
+	createRecord(sessionName: string, ipAddress: string): Promise<void>;
+	deleteRecord(sessionName: string): Promise<void>;
+	updateRecord(
+		oldName: string,
+		newName: string,
+		ipAddress: string,
+	): Promise<void>;
+	fqdn(sessionName: string): string;
+}
+
+export function createDNSManager(config: Config): DNSManager | null {
+	if (
+		!config.dns?.cloudflare_api_token ||
+		!config.dns?.cloudflare_zone_id ||
+		!config.dns?.domain
+	) {
+		return null;
+	}
+
+	const client = new CloudflareClient(
+		config.dns.cloudflare_api_token,
+		config.dns.cloudflare_zone_id,
+	);
+	const domain = config.dns.domain;
+
+	function fqdn(sessionName: string): string {
+		return `${sessionName}.${domain}`;
+	}
+
+	return {
+		fqdn,
+
+		async createRecord(sessionName: string, ipAddress: string): Promise<void> {
+			await client.createDNSRecord(fqdn(sessionName), ipAddress);
+		},
+
+		async deleteRecord(sessionName: string): Promise<void> {
+			const records = await client.listDNSRecords(fqdn(sessionName));
+			for (const record of records) {
+				await client.deleteDNSRecord(record.id);
+			}
+		},
+
+		async updateRecord(
+			oldName: string,
+			newName: string,
+			ipAddress: string,
+		): Promise<void> {
+			// Delete old record, create new one
+			const records = await client.listDNSRecords(fqdn(oldName));
+			for (const record of records) {
+				await client.deleteDNSRecord(record.id);
+			}
+			await client.createDNSRecord(fqdn(newName), ipAddress);
+		},
+	};
+}

--- a/tests/unit/cloudflare/client.test.ts
+++ b/tests/unit/cloudflare/client.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { CloudflareClient } from "@/cloudflare/client";
+
+describe("cloudflare/client", () => {
+	let server: ReturnType<typeof Bun.serve>;
+	let requests: Array<{ method: string; url: string; body: unknown }>;
+	let nextResponse: { status: number; body: unknown };
+
+	beforeEach(() => {
+		requests = [];
+		nextResponse = { status: 200, body: { success: true, errors: [], result: {} } };
+
+		server = Bun.serve({
+			port: 0,
+			fetch(req) {
+				const url = new URL(req.url);
+				const entry: { method: string; url: string; body: unknown } = {
+					method: req.method,
+					url: url.pathname + url.search,
+					body: null,
+				};
+				const p = req
+					.json()
+					.then((b) => {
+						entry.body = b;
+					})
+					.catch(() => {});
+				requests.push(entry);
+				return p.then(
+					() =>
+						new Response(JSON.stringify(nextResponse.body), {
+							status: nextResponse.status,
+							headers: { "Content-Type": "application/json" },
+						}),
+				);
+			},
+		});
+	});
+
+	afterEach(() => {
+		server.stop(true);
+	});
+
+	function client(zoneId = "zone-123") {
+		return new CloudflareClient(
+			"cf-token",
+			zoneId,
+			`http://localhost:${server.port}`,
+		);
+	}
+
+	test("createDNSRecord sends correct request", async () => {
+		const record = {
+			id: "rec-1",
+			type: "A",
+			name: "test.example.com",
+			content: "1.2.3.4",
+			ttl: 60,
+			proxied: false,
+		};
+		nextResponse = {
+			status: 200,
+			body: { success: true, errors: [], result: record },
+		};
+
+		const result = await client().createDNSRecord("test.example.com", "1.2.3.4");
+
+		expect(requests).toHaveLength(1);
+		expect(requests[0].method).toBe("POST");
+		expect(requests[0].url).toBe("/zones/zone-123/dns_records");
+		expect(requests[0].body).toEqual({
+			type: "A",
+			name: "test.example.com",
+			content: "1.2.3.4",
+			ttl: 60,
+			proxied: false,
+		});
+		expect(result).toEqual(record);
+	});
+
+	test("deleteDNSRecord sends DELETE request", async () => {
+		nextResponse = {
+			status: 200,
+			body: { success: true, errors: [], result: { id: "rec-1" } },
+		};
+
+		await client().deleteDNSRecord("rec-1");
+
+		expect(requests).toHaveLength(1);
+		expect(requests[0].method).toBe("DELETE");
+		expect(requests[0].url).toBe(
+			"/zones/zone-123/dns_records/rec-1",
+		);
+	});
+
+	test("listDNSRecords filters by name", async () => {
+		nextResponse = {
+			status: 200,
+			body: { success: true, errors: [], result: [] },
+		};
+
+		await client().listDNSRecords("test.example.com");
+
+		expect(requests).toHaveLength(1);
+		expect(requests[0].method).toBe("GET");
+		expect(requests[0].url).toContain("name=test.example.com");
+		expect(requests[0].url).toContain("type=A");
+	});
+
+	test("throws on API error", async () => {
+		nextResponse = {
+			status: 400,
+			body: {
+				success: false,
+				errors: [{ code: 1000, message: "Invalid zone" }],
+				result: null,
+			},
+		};
+
+		await expect(
+			client().createDNSRecord("test.example.com", "1.2.3.4"),
+		).rejects.toThrow("Cloudflare API error: Invalid zone");
+	});
+});

--- a/tests/unit/cloudflare/client.test.ts
+++ b/tests/unit/cloudflare/client.test.ts
@@ -9,7 +9,10 @@ describe("cloudflare/client", () => {
 
 	beforeEach(() => {
 		requests = [];
-		nextResponse = { status: 200, body: { success: true, errors: [], result: {} } };
+		nextResponse = {
+			status: 200,
+			body: { success: true, errors: [], result: {} },
+		};
 
 		server = Bun.serve({
 			port: 0,
@@ -64,7 +67,10 @@ describe("cloudflare/client", () => {
 			body: { success: true, errors: [], result: record },
 		};
 
-		const result = await client().createDNSRecord("test.example.com", "1.2.3.4");
+		const result = await client().createDNSRecord(
+			"test.example.com",
+			"1.2.3.4",
+		);
 
 		expect(requests).toHaveLength(1);
 		expect(requests[0].method).toBe("POST");
@@ -89,9 +95,7 @@ describe("cloudflare/client", () => {
 
 		expect(requests).toHaveLength(1);
 		expect(requests[0].method).toBe("DELETE");
-		expect(requests[0].url).toBe(
-			"/zones/zone-123/dns_records/rec-1",
-		);
+		expect(requests[0].url).toBe("/zones/zone-123/dns_records/rec-1");
 	});
 
 	test("listDNSRecords filters by name", async () => {

--- a/tests/unit/dns/manager.test.ts
+++ b/tests/unit/dns/manager.test.ts
@@ -5,7 +5,10 @@ import { createDNSManager } from "@/dns/manager";
 
 describe("dns/manager", () => {
 	test("returns null when DNS config is missing", () => {
-		const config: Config = { default_provider: "hetzner", ssh_key_source: "agent" };
+		const config: Config = {
+			default_provider: "hetzner",
+			ssh_key_source: "agent",
+		};
 		expect(createDNSManager(config)).toBeNull();
 	});
 

--- a/tests/unit/dns/manager.test.ts
+++ b/tests/unit/dns/manager.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Config } from "@/config/config";
+import { createDNSManager } from "@/dns/manager";
+
+describe("dns/manager", () => {
+	test("returns null when DNS config is missing", () => {
+		const config: Config = { default_provider: "hetzner", ssh_key_source: "agent" };
+		expect(createDNSManager(config)).toBeNull();
+	});
+
+	test("returns null when DNS config is partial", () => {
+		const config: Config = {
+			default_provider: "hetzner",
+			ssh_key_source: "agent",
+			dns: { domain: "example.com" },
+		};
+		expect(createDNSManager(config)).toBeNull();
+	});
+
+	test("returns manager when DNS config is complete", () => {
+		const config: Config = {
+			default_provider: "hetzner",
+			ssh_key_source: "agent",
+			dns: {
+				domain: "sandbox.example.com",
+				cloudflare_api_token: "cf-token",
+				cloudflare_zone_id: "zone-123",
+			},
+		};
+		const manager = createDNSManager(config);
+		expect(manager).not.toBeNull();
+	});
+
+	test("fqdn constructs correct hostname", () => {
+		const config: Config = {
+			default_provider: "hetzner",
+			ssh_key_source: "agent",
+			dns: {
+				domain: "sandbox.example.com",
+				cloudflare_api_token: "cf-token",
+				cloudflare_zone_id: "zone-123",
+			},
+		};
+		const manager = createDNSManager(config);
+		expect(manager?.fqdn("my-session")).toBe("my-session.sandbox.example.com");
+	});
+});


### PR DESCRIPTION
## Summary

- Adds Cloudflare DNS integration to automatically manage A records for sessions
- Creates `<session-name>.<domain>` DNS records on `sandctl new`, cleans them up on `sandctl destroy`, and updates them on `sandctl rename`
- All DNS operations are best-effort — failures produce warnings but never block the primary session operation
- DNS is opt-in via a new `dns` config section in `~/.sandctl/config`

## Configuration

```yaml
dns:
  domain: sandbox.example.com
  cloudflare_api_token: <token with Zone:DNS:Edit permission>
  cloudflare_zone_id: <zone-id>
```

## Changes

- **New**: `src/cloudflare/client.ts` — Cloudflare API v4 client for DNS record CRUD
- **New**: `src/dns/manager.ts` — DNS manager that abstracts record lifecycle
- **Modified**: `src/config/config.ts` — Added `DNSConfig` interface and `dns` field to `Config`
- **Modified**: `src/commands/new.ts` — Creates DNS record after session is running
- **Modified**: `src/commands/destroy.ts` — Deletes DNS record on session destruction
- **Modified**: `src/commands/rename.ts` — Updates DNS record on session rename
- **New**: Tests for Cloudflare client and DNS manager

## Test plan

- [x] All 309 unit tests pass (301 existing + 8 new)
- [ ] Manual test: configure DNS and verify record creation on `sandctl new`
- [ ] Manual test: verify record cleanup on `sandctl destroy`
- [ ] Manual test: verify record update on `sandctl rename`
- [ ] Verify no DNS operations when `dns` config section is absent

Closes CHR-73