### PR TITLE
Add DigitalOcean provider and harden cloud-init provisioning

### DIFF
--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -76,7 +76,9 @@ function buildCommand(options: LogsOptions): string {
 	return `cat ${LOG_FILE}`;
 }
 
-function parseCommand(command: string): { command: string; args: string[] } | null {
+function parseCommand(
+	command: string,
+): { command: string; args: string[] } | null {
 	const trimmed = command.trim();
 	if (!trimmed) {
 		return null;
@@ -153,12 +155,10 @@ export async function runLogs(
 	assertRunnable(session);
 
 	const config = await dependencies.loadConfig(configPath);
-	const client = dependencies.createSSHClient(
-		{
-			...buildSSHOptions(config, session.ip_address),
-			username: "root",
-		},
-	);
+	const client = dependencies.createSSHClient({
+		...buildSSHOptions(config, session.ip_address),
+		username: "root",
+	});
 
 	const command = buildCommand(options);
 

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { Command } from "commander";
 import {
 	assertRunnable,
@@ -21,6 +22,8 @@ const LOG_FILE = "/var/log/cloud-init-output.log";
 interface LogsOptions {
 	follow?: boolean;
 	lines?: string;
+	noPager?: boolean;
+	pager?: boolean;
 }
 
 interface Dependencies {
@@ -38,10 +41,13 @@ interface Dependencies {
 	) => Promise<ExecResult>;
 	stdout: {
 		write(chunk: string | Uint8Array): boolean;
+		isTTY?: boolean;
 	};
 	stderr: {
 		write(chunk: string | Uint8Array): boolean;
+		isTTY?: boolean;
 	};
+	pageOutput: (content: string) => Promise<void>;
 }
 
 const defaultDependencies: Dependencies = {
@@ -56,6 +62,7 @@ const defaultDependencies: Dependencies = {
 		}),
 	stdout: process.stdout,
 	stderr: process.stderr,
+	pageOutput: defaultPageOutput,
 };
 
 function buildCommand(options: LogsOptions): string {
@@ -67,6 +74,68 @@ function buildCommand(options: LogsOptions): string {
 		return `tail -n ${options.lines} ${LOG_FILE}`;
 	}
 	return `cat ${LOG_FILE}`;
+}
+
+function parseCommand(command: string): { command: string; args: string[] } | null {
+	const trimmed = command.trim();
+	if (!trimmed) {
+		return null;
+	}
+
+	const parts = trimmed.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
+	if (!parts || parts.length === 0) {
+		return null;
+	}
+
+	const [rawCommand, ...rawArgs] = parts;
+	const unquote = (value: string) => {
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			return value.slice(1, -1);
+		}
+		return value;
+	};
+
+	return {
+		command: unquote(rawCommand),
+		args: rawArgs.map(unquote),
+	};
+}
+
+function pagerCommand(): { command: string; args: string[] } {
+	const fromEnv = process.env.PAGER?.trim();
+	if (fromEnv) {
+		const parsed = parseCommand(fromEnv);
+		if (parsed) {
+			return parsed;
+		}
+	}
+
+	return { command: "less", args: ["-R"] };
+}
+
+async function defaultPageOutput(content: string): Promise<void> {
+	const pager = pagerCommand();
+
+	await new Promise<void>((resolve) => {
+		const child = spawn(pager.command, pager.args, {
+			stdio: ["pipe", "inherit", "inherit"],
+		});
+
+		child.on("error", () => {
+			process.stdout.write(content);
+			resolve();
+		});
+
+		child.on("close", () => {
+			resolve();
+		});
+
+		child.stdin.write(content);
+		child.stdin.end();
+	});
 }
 
 export async function runLogs(
@@ -85,7 +154,10 @@ export async function runLogs(
 
 	const config = await dependencies.loadConfig(configPath);
 	const client = dependencies.createSSHClient(
-		buildSSHOptions(config, session.ip_address),
+		{
+			...buildSSHOptions(config, session.ip_address),
+			username: "root",
+		},
 	);
 
 	const command = buildCommand(options);
@@ -100,7 +172,12 @@ export async function runLogs(
 
 		const result = await dependencies.runCommand(c, command);
 		if (result.stdout) {
-			dependencies.stdout.write(result.stdout);
+			const pagerDisabled = options.noPager || options.pager === false;
+			if (dependencies.stdout.isTTY && !pagerDisabled) {
+				await dependencies.pageOutput(result.stdout);
+			} else {
+				dependencies.stdout.write(result.stdout);
+			}
 		}
 		if (result.stderr) {
 			dependencies.stderr.write(result.stderr);
@@ -115,6 +192,7 @@ export function registerLogsCommand(): Command {
 		.argument("<name>")
 		.option("-f, --follow", "Follow log output in real-time")
 		.option("-n, --lines <lines>", "Number of lines to show")
+		.option("--no-pager", "Write logs directly to stdout without paging")
 		.action(async (name: string, options: LogsOptions, command: Command) => {
 			const globals = command.optsWithGlobals() as {
 				config?: string;

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -718,7 +718,10 @@ export async function runNew(
 
 		dependencies.log("Waiting for VM to be ready...");
 		const waitReadyStartedAt = dependencies.nowMs();
-		await provider.waitReady(createdVM.id, waitReadyTimeoutMs(normalizedOptions));
+		await provider.waitReady(
+			createdVM.id,
+			waitReadyTimeoutMs(normalizedOptions),
+		);
 		waitReadyMs = Math.max(0, dependencies.nowMs() - waitReadyStartedAt);
 		dependencies.log(`VM became reachable in ${formatElapsed(waitReadyMs)}.`);
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -19,7 +19,11 @@ import {
 	load,
 	type ProviderConfig,
 } from "@/config/config";
-import { assembleUserData, generateCloudInit } from "@/provider/cloud-init";
+import {
+	assembleUserData,
+	generateCloudInit,
+	type UserDataLayer,
+} from "@/provider/cloud-init";
 import type { SnapshotReference } from "@/provider/interface";
 import { supportsSnapshots } from "@/provider/interface";
 import { get as getProviderFromRegistry } from "@/provider/registry";
@@ -56,6 +60,7 @@ interface NewOptions {
 	bare?: boolean;
 	timings?: boolean;
 	noCache?: boolean;
+	cache?: boolean;
 }
 
 interface NewCommandSpinner {
@@ -274,7 +279,7 @@ const AGENT_TOOL_CHECKS: readonly { name: string; command: string }[] = [
 	{ name: "docker", command: "docker --version" },
 ];
 
-async function defaultWaitForCloudInit(
+export async function defaultWaitForCloudInit(
 	config: Config,
 	host: string,
 	createClient: (options: SSHClientOptions) => SSHRuntimeClient,
@@ -310,7 +315,29 @@ async function defaultWaitForCloudInit(
 		);
 	}
 
-	// Phase 2: cloud-init is done. Verify the agent-user tools installed by
+	// Phase 2: boot-finished exists, but cloud-init may still report a degraded
+	// final state (for example, a template script failed in scripts_user). Treat
+	// any non-zero cloud-init status as a provisioning failure so we do not
+	// create reusable snapshots from a broken boot.
+	const statusClient = createClient(sshOptions);
+	const statusResult = await withSSHClient(statusClient, (c) =>
+		sshExec(c, "cloud-init status --wait --long"),
+	);
+	if (statusResult.exitCode !== 0) {
+		const tailClient = createClient(sshOptions);
+		const tailResult = await withSSHClient(tailClient, (c) =>
+			sshExec(c, "tail -n 200 /var/log/cloud-init-output.log"),
+		);
+		const logTail =
+			tailResult.exitCode === 0
+				? tailResult.stdout
+				: `<unable to read cloud-init-output.log: exit ${tailResult.exitCode} ${tailResult.stderr.trim()}>`;
+		throw new Error(
+			`cloud-init reported a degraded state (exit ${statusResult.exitCode}).\nstdout:\n${statusResult.stdout.trim() || "<empty>"}\nstderr:\n${statusResult.stderr.trim() || "<empty>"}\n\nLast 200 lines of /var/log/cloud-init-output.log:\n${logTail}`,
+		);
+	}
+
+	// Phase 3: cloud-init is done and healthy. Verify the agent-user tools installed by
 	// runcmd are actually runnable. Run each check exactly once and capture
 	// exit code + stderr so a failure tells us *which* tool is broken. If
 	// anything fails, also grab the tail of cloud-init-output.log so we can
@@ -372,13 +399,6 @@ async function setupGitConfigViaSSH(
 		);
 	} else {
 		gitConfigContent = `[user]\n\tname = ${config.git_user_name}\n\temail = ${config.git_user_email}\n`;
-	}
-
-	if (
-		config.ssh_key_source === "agent" &&
-		!gitConfigContent.includes("insteadOf = https://github.com/")
-	) {
-		gitConfigContent += `\n[url "ssh://git@github.com/"]\n\tinsteadOf = https://github.com/\n`;
 	}
 
 	const encoded = Buffer.from(gitConfigContent).toString("base64");
@@ -497,11 +517,19 @@ interface TimingSummary {
 	backgroundSnapshotDeferred: boolean;
 }
 
+function normalizedNewOptions(options: NewOptions): NewOptions {
+	return {
+		...options,
+		noCache: options.noCache || options.cache === false,
+	};
+}
+
 export async function runNew(
 	options: NewOptions,
 	deps: Partial<Dependencies> = {},
 	configPath?: string,
 ): Promise<NewResult> {
+	const normalizedOptions = normalizedNewOptions(options);
 	const dependencies = {
 		...defaultDependencies,
 		...deps,
@@ -518,40 +546,43 @@ export async function runNew(
 	let claudeSetupMs: number | undefined;
 	let backgroundSnapshotDeferred = false;
 	const providerName =
-		options.provider ?? config.default_provider ?? DEFAULT_PROVIDER;
+		normalizedOptions.provider ?? config.default_provider ?? DEFAULT_PROVIDER;
 
 	let resolvedServerType: string | undefined;
-	if (options.size) {
-		const vmSize = resolveSize(options.size, providerName);
+	if (normalizedOptions.size) {
+		const vmSize = resolveSize(normalizedOptions.size, providerName);
 		if (!vmSize) {
 			throw new Error(
-				`unknown size '${options.size}'. Available sizes:\n${sizesHelpText(providerName)}`,
+				`unknown size '${normalizedOptions.size}'. Available sizes:\n${sizesHelpText(providerName)}`,
 			);
 		}
 		resolvedServerType = vmSize.serverType;
 	}
 
-	if (options.template && normalizeTemplateName(options.template) === "base") {
+	if (
+		normalizedOptions.template &&
+		normalizeTemplateName(normalizedOptions.template) === "base"
+	) {
 		throw new Error(
 			"the 'base' template is applied automatically. Use `sandctl template edit base` to modify it.",
 		);
 	}
 
-	if (options.bare && options.template) {
+	if (normalizedOptions.bare && normalizedOptions.template) {
 		throw new Error("--bare and -T cannot be used together.");
 	}
 
 	let namedTemplateContent: string | undefined;
-	if (options.template) {
+	if (normalizedOptions.template) {
 		try {
 			const template = await dependencies.templateStore.getInitScript(
-				options.template,
+				normalizedOptions.template,
 			);
 			namedTemplateContent = template.script;
 		} catch (error) {
 			if (error instanceof TemplateNotFoundError) {
 				throw new Error(
-					`template '${options.template}' not found. Use 'sandctl template list' to see available templates`,
+					`template '${normalizedOptions.template}' not found. Use 'sandctl template list' to see available templates`,
 				);
 			}
 			throw error;
@@ -559,7 +590,7 @@ export async function runNew(
 	}
 
 	let userBaseContent: string | undefined;
-	if (!options.bare) {
+	if (!normalizedOptions.bare) {
 		try {
 			const baseTemplate =
 				await dependencies.templateStore.getInitScript("base");
@@ -571,10 +602,22 @@ export async function runNew(
 		}
 	}
 
-	const globalBase = generateCloudInit();
-	const additionalLayers: string[] = [];
-	if (userBaseContent) additionalLayers.push(userBaseContent);
-	if (namedTemplateContent) additionalLayers.push(namedTemplateContent);
+	const globalBase = generateCloudInit({
+		githubToken: config.github_token,
+	});
+	const additionalLayers: UserDataLayer[] = [];
+	if (userBaseContent) {
+		additionalLayers.push({
+			name: "user cloud-init",
+			content: userBaseContent,
+		});
+	}
+	if (namedTemplateContent) {
+		additionalLayers.push({
+			name: "template",
+			content: namedTemplateContent,
+		});
+	}
 	const userData = assembleUserData(globalBase, additionalLayers);
 
 	const providerConfig = getProviderConfig(config, providerName);
@@ -615,7 +658,7 @@ export async function runNew(
 	);
 
 	let snapshot: SnapshotReference | null = null;
-	if (options.noCache) {
+	if (normalizedOptions.noCache) {
 		dependencies.log("Snapshot cache disabled (--no-cache).");
 	} else if (snapshotProvider) {
 		try {
@@ -643,7 +686,7 @@ export async function runNew(
 		if (snapshot) {
 			createdVM = await provider.create({
 				name: sessionID,
-				region: options.region,
+				region: normalizedOptions.region,
 				serverType: resolvedServerType,
 				image: String(snapshot.id),
 				sshKeyIDs: [sshKeyID],
@@ -652,9 +695,9 @@ export async function runNew(
 		} else {
 			createdVM = await provider.create({
 				name: sessionID,
-				region: options.region,
+				region: normalizedOptions.region,
 				serverType: resolvedServerType,
-				image: options.image,
+				image: normalizedOptions.image,
 				sshKeyIDs: [sshKeyID],
 				userData,
 			});
@@ -675,7 +718,7 @@ export async function runNew(
 
 		dependencies.log("Waiting for VM to be ready...");
 		const waitReadyStartedAt = dependencies.nowMs();
-		await provider.waitReady(createdVM.id, waitReadyTimeoutMs(options));
+		await provider.waitReady(createdVM.id, waitReadyTimeoutMs(normalizedOptions));
 		waitReadyMs = Math.max(0, dependencies.nowMs() - waitReadyStartedAt);
 		dependencies.log(`VM became reachable in ${formatElapsed(waitReadyMs)}.`);
 
@@ -712,7 +755,7 @@ export async function runNew(
 					`Cloud-init completed in ${formatElapsed(cloudInitMs)}.`,
 				);
 
-				if (snapshotProvider && !options.noCache) {
+				if (snapshotProvider && !normalizedOptions.noCache) {
 					backgroundSnapshotDeferred = true;
 					backgroundTasks = (async () => {
 						try {
@@ -838,6 +881,7 @@ export async function runNewCommand(
 	configPath?: string,
 	deps: Partial<NewCommandDependencies> = {},
 ): Promise<Session> {
+	const normalizedOptions = normalizedNewOptions(options);
 	const dependencies = {
 		...defaultNewCommandDependencies,
 		...deps,
@@ -846,7 +890,7 @@ export async function runNewCommand(
 	const spinner = dependencies.createSpinner("Creating VM...");
 	let result: NewResult;
 	try {
-		result = await dependencies.runNew(options, configPath, {
+		result = await dependencies.runNew(normalizedOptions, configPath, {
 			onProgress: (message: string) => {
 				spinner.update(message);
 			},
@@ -860,8 +904,8 @@ export async function runNewCommand(
 	const { session, backgroundTasks } = result;
 
 	const shouldConsole =
-		!options.noConsole &&
-		!options.timings &&
+		!normalizedOptions.noConsole &&
+		!normalizedOptions.timings &&
 		dependencies.isInteractive() &&
 		session.ip_address;
 
@@ -885,19 +929,19 @@ export async function runNewCommand(
 				`Session was created successfully. Use 'sandctl console ${session.id}' to connect manually.`,
 			);
 		}
-	} else if (!options.noConsole && !options.timings) {
+	} else if (!normalizedOptions.noConsole && !normalizedOptions.timings) {
 		dependencies.log(`Use 'sandctl console ${session.id}' to connect.`);
 		dependencies.log(`Use 'sandctl destroy ${session.id}' when done.`);
 	}
 
-	if (options.timings) {
+	if (normalizedOptions.timings) {
 		for (const line of formatTimingSummary(result.timingSummary)) {
 			dependencies.log(line);
 		}
 	}
 
 	// Wait for background tasks (e.g. snapshot creation) after the console exits
-	if (backgroundTasks && !options.timings) {
+	if (backgroundTasks && !normalizedOptions.timings) {
 		await backgroundTasks;
 	}
 

--- a/src/hetzner/client.ts
+++ b/src/hetzner/client.ts
@@ -48,6 +48,7 @@ export interface HetznerImage {
 	type: string;
 	status: string;
 	description: string;
+	created: string;
 	labels: Record<string, string>;
 	created_from: { id: number; name: string } | null;
 }

--- a/src/hetzner/snapshots.ts
+++ b/src/hetzner/snapshots.ts
@@ -28,9 +28,7 @@ export async function findBaseSnapshot(
 	const images = await client.listImages(SNAPSHOT_LABEL_SELECTOR);
 	const expected = snapshotDescription(userData);
 	const matches = images
-		.filter(
-			(img) => img.description === expected && img.status === "available",
-		)
+		.filter((img) => img.description === expected && img.status === "available")
 		.sort((a, b) => Date.parse(b.created) - Date.parse(a.created));
 	const match = matches[0];
 	return match ?? null;

--- a/src/hetzner/snapshots.ts
+++ b/src/hetzner/snapshots.ts
@@ -27,9 +27,12 @@ export async function findBaseSnapshot(
 ): Promise<HetznerImage | null> {
 	const images = await client.listImages(SNAPSHOT_LABEL_SELECTOR);
 	const expected = snapshotDescription(userData);
-	const match = images.find(
-		(img) => img.description === expected && img.status === "available",
-	);
+	const matches = images
+		.filter(
+			(img) => img.description === expected && img.status === "available",
+		)
+		.sort((a, b) => Date.parse(b.created) - Date.parse(a.created));
+	const match = matches[0];
 	return match ?? null;
 }
 
@@ -67,9 +70,13 @@ export async function cleanupOldSnapshots(
 ): Promise<void> {
 	const images = await client.listImages(SNAPSHOT_LABEL_SELECTOR);
 	const currentDesc = snapshotDescription(userData);
+	const currentMatches = images
+		.filter((img) => img.description === currentDesc)
+		.sort((a, b) => Date.parse(b.created) - Date.parse(a.created));
+	const currentToKeep = currentMatches[0]?.id;
 
 	for (const img of images) {
-		if (img.description !== currentDesc) {
+		if (img.description !== currentDesc || img.id !== currentToKeep) {
 			await client.deleteImage(String(img.id));
 		}
 	}

--- a/src/provider/cloud-init.ts
+++ b/src/provider/cloud-init.ts
@@ -22,7 +22,9 @@ interface GenerateCloudInitOptions {
 }
 
 function generateGitHubTokenSetup(githubToken: string): string {
-	const tokenBase64 = Buffer.from(`${githubToken}\n`, "utf8").toString("base64");
+	const tokenBase64 = Buffer.from(`${githubToken}\n`, "utf8").toString(
+		"base64",
+	);
 	const profileBase64 = Buffer.from(
 		`if [ -f /home/agent/.config/sandctl/github-token ]; then
   export GH_TOKEN="$(cat /home/agent/.config/sandctl/github-token)"
@@ -182,10 +184,7 @@ export interface UserDataLayer {
 }
 
 function bannerLabel(name: string): string {
-	return name
-		.trim()
-		.replace(/\s+/g, " ")
-		.toUpperCase();
+	return name.trim().replace(/\s+/g, " ").toUpperCase();
 }
 
 function bannerText(name: string, phase: "BEGIN" | "END"): string {
@@ -201,12 +200,7 @@ function annotateShellScriptLayer(content: string, name: string): string {
 	const begin = `echo '${bannerText(name, "BEGIN")}'`;
 	const trap = `trap 'status=$?; echo "${bannerText(name, "END")} (exit \${status})"' EXIT`;
 
-	return [
-		...(shebang ? [shebang] : []),
-		begin,
-		trap,
-		body.trimStart(),
-	]
+	return [...(shebang ? [shebang] : []), begin, trap, body.trimStart()]
 		.filter((line) => line.length > 0)
 		.join("\n")
 		.concat("\n");
@@ -265,11 +259,9 @@ export function assembleUserData(
 	globalBase: string,
 	layers: Array<string | UserDataLayer> = [],
 ): string {
-	const annotatedGlobalBase = annotateLayer(
-		"global cloud-init",
-		globalBase,
-		{ injectMergeHow: false },
-	);
+	const annotatedGlobalBase = annotateLayer("global cloud-init", globalBase, {
+		injectMergeHow: false,
+	});
 
 	if (layers.length === 0) {
 		return annotatedGlobalBase;

--- a/src/provider/cloud-init.ts
+++ b/src/provider/cloud-init.ts
@@ -1,3 +1,5 @@
+import YAML from "yaml";
+
 export function generatePostSnapshotSSHSetup(): string {
 	return [
 		"mkdir -p /home/agent/.ssh",
@@ -15,7 +17,47 @@ const AGENT_ZSHRC_BASE64 = Buffer.from(
 	"utf8",
 ).toString("base64");
 
-export function generateCloudInit(): string {
+interface GenerateCloudInitOptions {
+	githubToken?: string;
+}
+
+function generateGitHubTokenSetup(githubToken: string): string {
+	const tokenBase64 = Buffer.from(`${githubToken}\n`, "utf8").toString("base64");
+	const profileBase64 = Buffer.from(
+		`if [ -f /home/agent/.config/sandctl/github-token ]; then
+  export GH_TOKEN="$(cat /home/agent/.config/sandctl/github-token)"
+  export GITHUB_TOKEN="$GH_TOKEN"
+fi
+`,
+		"utf8",
+	).toString("base64");
+	const ghHostsBase64 = Buffer.from(
+		`github.com:
+    oauth_token: ${githubToken}
+    git_protocol: https
+`,
+		"utf8",
+	).toString("base64");
+
+	return `  - |
+    install -d -m 700 /home/agent/.config /home/agent/.config/sandctl /home/agent/.config/gh
+    echo '${tokenBase64}' | base64 -d > /home/agent/.config/sandctl/github-token
+    echo '${ghHostsBase64}' | base64 -d > /home/agent/.config/gh/hosts.yml
+    echo '${profileBase64}' | base64 -d > /etc/profile.d/sandctl-github-token.sh
+    chown -R agent:agent /home/agent/.config
+    chmod 600 /home/agent/.config/sandctl/github-token
+    chmod 600 /home/agent/.config/gh/hosts.yml
+    chmod 600 /etc/profile.d/sandctl-github-token.sh
+`;
+}
+
+export function generateCloudInit(
+	options: GenerateCloudInitOptions = {},
+): string {
+	const githubTokenSetup = options.githubToken
+		? generateGitHubTokenSetup(options.githubToken)
+		: "";
+
 	return `#cloud-config
 packages:
   - docker.io
@@ -29,8 +71,10 @@ users:
       - sudo
       - docker
     sudo: "ALL=(ALL) NOPASSWD:ALL"
-    ssh_authorized_keys: []
 runcmd:
+  - |
+    echo 'agent ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/99-agent
+    chmod 440 /etc/sudoers.d/99-agent
   - |
     mkdir -p /home/agent/.ssh
     if [ -f /root/.ssh/authorized_keys ]; then
@@ -41,6 +85,7 @@ runcmd:
     chown -R agent:agent /home/agent/.ssh
     chmod 700 /home/agent/.ssh
     chmod 600 /home/agent/.ssh/authorized_keys
+${githubTokenSetup}
   - |
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
@@ -126,6 +171,72 @@ const MERGE_HOW_DIRECTIVE = `merge_how:
   - name: dict
     settings: [no_replace, recurse_list]`;
 
+const MERGE_HOW_VALUE = [
+	{ name: "list", settings: ["append"] },
+	{ name: "dict", settings: ["no_replace", "recurse_list"] },
+];
+
+export interface UserDataLayer {
+	name: string;
+	content: string;
+}
+
+function bannerLabel(name: string): string {
+	return name
+		.trim()
+		.replace(/\s+/g, " ")
+		.toUpperCase();
+}
+
+function bannerText(name: string, phase: "BEGIN" | "END"): string {
+	return `========== SANDCTL ${phase} ${bannerLabel(name)} ==========`;
+}
+
+function annotateShellScriptLayer(content: string, name: string): string {
+	const normalized = content.endsWith("\n") ? content : `${content}\n`;
+	const lines = normalized.split("\n");
+	const hasShebang = lines[0]?.startsWith("#!");
+	const shebang = hasShebang ? lines[0] : "";
+	const body = hasShebang ? lines.slice(1).join("\n") : normalized;
+	const begin = `echo '${bannerText(name, "BEGIN")}'`;
+	const trap = `trap 'status=$?; echo "${bannerText(name, "END")} (exit \${status})"' EXIT`;
+
+	return [
+		...(shebang ? [shebang] : []),
+		begin,
+		trap,
+		body.trimStart(),
+	]
+		.filter((line) => line.length > 0)
+		.join("\n")
+		.concat("\n");
+}
+
+function annotateCloudConfigLayer(
+	content: string,
+	name: string,
+	options: { injectMergeHow: boolean },
+): string {
+	const parsed = YAML.parse(content);
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return content;
+	}
+
+	const doc = parsed as Record<string, unknown>;
+	if (options.injectMergeHow && !("merge_how" in doc)) {
+		doc.merge_how = MERGE_HOW_VALUE;
+	}
+
+	const existingRuncmd = Array.isArray(doc.runcmd) ? [...doc.runcmd] : [];
+	doc.runcmd = [
+		`echo '${bannerText(name, "BEGIN")}'`,
+		...existingRuncmd,
+		`echo '${bannerText(name, "END")}'`,
+	];
+
+	return `#cloud-config\n${YAML.stringify(doc)}`;
+}
+
 function ensureMergeDirective(content: string): string {
 	if (detectContentType(content) !== "text/cloud-config") {
 		return content;
@@ -139,17 +250,43 @@ function ensureMergeDirective(content: string): string {
 	);
 }
 
+function annotateLayer(
+	name: string,
+	content: string,
+	options: { injectMergeHow: boolean },
+): string {
+	if (detectContentType(content) === "text/cloud-config") {
+		return annotateCloudConfigLayer(content, name, options);
+	}
+	return annotateShellScriptLayer(content, name);
+}
+
 export function assembleUserData(
 	globalBase: string,
-	layers: string[] = [],
+	layers: Array<string | UserDataLayer> = [],
 ): string {
+	const annotatedGlobalBase = annotateLayer(
+		"global cloud-init",
+		globalBase,
+		{ injectMergeHow: false },
+	);
+
 	if (layers.length === 0) {
-		return globalBase;
+		return annotatedGlobalBase;
 	}
 
 	const boundary = "==SANDCTL==";
-	const processedLayers = layers.map(ensureMergeDirective);
-	const allLayers = [globalBase, ...processedLayers];
+	const processedLayers = layers.map((layer, index) => {
+		if (typeof layer === "string") {
+			return annotateLayer(`layer ${index + 1}`, ensureMergeDirective(layer), {
+				injectMergeHow: true,
+			});
+		}
+		return annotateLayer(layer.name, ensureMergeDirective(layer.content), {
+			injectMergeHow: true,
+		});
+	});
+	const allLayers = [annotatedGlobalBase, ...processedLayers];
 
 	const parts = allLayers.map((content) => {
 		const contentType = detectContentType(content);

--- a/tests/unit/commands/logs.test.ts
+++ b/tests/unit/commands/logs.test.ts
@@ -4,6 +4,56 @@ import { runLogs } from "@/commands/logs";
 import { agentModeConfig, makeRunningSession } from "../../support/fixtures";
 
 describe("commands/logs", () => {
+	test("connects as root to read cloud-init logs", async () => {
+		let username = "";
+
+		await runLogs(
+			"alice",
+			{},
+			{
+				store: {
+					get: async () => makeRunningSession(),
+				},
+				loadConfig: async () => agentModeConfig,
+				createSSHClient: (options) => {
+					username = options.username;
+					return {
+						connect: async () => {},
+						close: async () => {},
+						exec: async () => {
+							throw new Error("not used");
+						},
+						shell: async () => {
+							throw new Error("not used");
+						},
+					};
+				},
+				runCommand: async () => ({
+					stdout: "",
+					stderr: "",
+					exitCode: 0,
+				}),
+				runStreamingCommand: async () => ({
+					stdout: "",
+					stderr: "",
+					exitCode: 0,
+				}),
+				stdout: {
+					write() {
+						return true;
+					},
+				},
+				stderr: {
+					write() {
+						return true;
+					},
+				},
+			},
+		);
+
+		expect(username).toBe("root");
+	});
+
 	test("runs cat on cloud-init log by default", async () => {
 		const commands: string[] = [];
 		let output = "";
@@ -57,6 +107,114 @@ describe("commands/logs", () => {
 		expect(output).toBe("cloud-init log output\n");
 	});
 
+	test("pages non-follow output in interactive terminals", async () => {
+		let paged = "";
+		let wroteToStdout = false;
+
+		await runLogs(
+			"alice",
+			{},
+			{
+				store: {
+					get: async () => makeRunningSession(),
+				},
+				loadConfig: async () => agentModeConfig,
+				createSSHClient: () => ({
+					connect: async () => {},
+					close: async () => {},
+					exec: async () => {
+						throw new Error("not used");
+					},
+					shell: async () => {
+						throw new Error("not used");
+					},
+				}),
+				runCommand: async () => ({
+					stdout: "cloud-init log output\n",
+					stderr: "",
+					exitCode: 0,
+				}),
+				runStreamingCommand: async () => ({
+					stdout: "",
+					stderr: "",
+					exitCode: 0,
+				}),
+				pageOutput: async (content: string) => {
+					paged += content;
+				},
+				stdout: {
+					write() {
+						wroteToStdout = true;
+						return true;
+					},
+					isTTY: true,
+				},
+				stderr: {
+					write() {
+						return true;
+					},
+				},
+			},
+		);
+
+		expect(paged).toBe("cloud-init log output\n");
+		expect(wroteToStdout).toBe(false);
+	});
+
+	test("writes directly to stdout when --no-pager is set", async () => {
+		let paged = false;
+		let output = "";
+
+		await runLogs(
+			"alice",
+			{ noPager: true },
+			{
+				store: {
+					get: async () => makeRunningSession(),
+				},
+				loadConfig: async () => agentModeConfig,
+				createSSHClient: () => ({
+					connect: async () => {},
+					close: async () => {},
+					exec: async () => {
+						throw new Error("not used");
+					},
+					shell: async () => {
+						throw new Error("not used");
+					},
+				}),
+				runCommand: async () => ({
+					stdout: "cloud-init log output\n",
+					stderr: "",
+					exitCode: 0,
+				}),
+				runStreamingCommand: async () => ({
+					stdout: "",
+					stderr: "",
+					exitCode: 0,
+				}),
+				pageOutput: async () => {
+					paged = true;
+				},
+				stdout: {
+					write(chunk: string | Uint8Array) {
+						output += chunk.toString();
+						return true;
+					},
+					isTTY: true,
+				},
+				stderr: {
+					write() {
+						return true;
+					},
+				},
+			},
+		);
+
+		expect(paged).toBe(false);
+		expect(output).toBe("cloud-init log output\n");
+	});
+
 	test("uses tail -n when --lines is specified", async () => {
 		const commands: string[] = [];
 
@@ -105,6 +263,7 @@ describe("commands/logs", () => {
 
 	test("uses tail -f when --follow is specified", async () => {
 		const streamCommands: string[] = [];
+		let paged = false;
 
 		await runLogs(
 			"alice",
@@ -133,10 +292,14 @@ describe("commands/logs", () => {
 					streamCommands.push(command);
 					return { stdout: "", stderr: "", exitCode: 0 };
 				},
+				pageOutput: async () => {
+					paged = true;
+				},
 				stdout: {
 					write() {
 						return true;
 					},
+					isTTY: true,
 				},
 				stderr: {
 					write() {
@@ -149,6 +312,7 @@ describe("commands/logs", () => {
 		expect(streamCommands).toEqual([
 			"tail -n 10 -f /var/log/cloud-init-output.log",
 		]);
+		expect(paged).toBe(false);
 	});
 
 	test("combines --follow and --lines", async () => {

--- a/tests/unit/commands/new-template.test.ts
+++ b/tests/unit/commands/new-template.test.ts
@@ -105,6 +105,9 @@ describe("commands/new --template layering", () => {
 		expect(userData).toContain("text/cloud-config");
 		expect(userData).toContain("nginx");
 		expect(userData).toContain("name: agent");
+		expect(userData).toContain("SANDCTL BEGIN GLOBAL CLOUD-INIT");
+		expect(userData).toContain("SANDCTL BEGIN TEMPLATE");
+		expect(userData).toContain("SANDCTL END TEMPLATE");
 	});
 
 	test("assembles user_data with user base template and named template", async () => {
@@ -154,6 +157,9 @@ describe("commands/new --template layering", () => {
 		expect(userData).toContain("git");
 		expect(userData).toContain("nginx");
 		expect(userData).toContain("text/x-shellscript");
+		expect(userData).toContain("SANDCTL BEGIN GLOBAL CLOUD-INIT");
+		expect(userData).toContain("SANDCTL BEGIN USER CLOUD-INIT");
+		expect(userData).toContain("SANDCTL BEGIN TEMPLATE");
 	});
 
 	test("sends plain cloud-config when no templates exist", async () => {
@@ -198,6 +204,53 @@ describe("commands/new --template layering", () => {
 		expect(userData).not.toContain("multipart/mixed");
 		expect(userData).toContain("#cloud-config");
 		expect(userData).toContain("name: agent");
+		expect(userData).toContain("SANDCTL BEGIN GLOBAL CLOUD-INIT");
+		expect(userData).toContain("SANDCTL END GLOBAL CLOUD-INIT");
+	});
+
+	test("injects github token into global cloud-init when configured", async () => {
+		const createCalls: CreateOpts[] = [];
+		const provider = makeProvider({
+			create: async (opts) => {
+				createCalls.push(opts);
+				return {
+					id: "vm-123",
+					name: "violet",
+					status: "running",
+					ipAddress: "203.0.113.10",
+					region: "ash",
+					serverType: "cpx31",
+					createdAt: "2026-02-22T00:00:00Z",
+				};
+			},
+		});
+
+		await runNew(
+			{},
+			{
+				loadConfig: async () => ({
+					...baseProviderConfig,
+					github_token: "ghp_test_token",
+				}),
+				resolveProvider: () => provider,
+				generateSessionID: () => "violet",
+				getPublicKey: async () => "ssh-ed25519 AAAA test@local",
+				waitForCloudInit: async () => {},
+				setupGitConfig: async () => {},
+				store: {
+					list: async () => [],
+					add: async () => {},
+					update: async () => {},
+				},
+				templateStore: makeTemplateStore({}),
+			},
+		);
+
+		expect(createCalls).toHaveLength(1);
+		const userData = createCalls[0].userData;
+		expect(userData).toBeDefined();
+		expect(userData).toContain("/home/agent/.config/sandctl/github-token");
+		expect(userData).toContain("/home/agent/.config/gh/hosts.yml");
 	});
 
 	test("applies user base template even without -T flag", async () => {
@@ -242,6 +295,8 @@ describe("commands/new --template layering", () => {
 		// User base template present — should be MIME multipart
 		expect(userData).toContain("multipart/mixed");
 		expect(userData).toContain("vim");
+		expect(userData).toContain("SANDCTL BEGIN USER CLOUD-INIT");
+		expect(userData).toContain("SANDCTL END USER CLOUD-INIT");
 	});
 
 	test("rejects -T base with descriptive error", async () => {

--- a/tests/unit/commands/new.test.ts
+++ b/tests/unit/commands/new.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { type NewResult, runNew, runNewCommand } from "@/commands/new";
+import {
+	type NewResult,
+	defaultWaitForCloudInit,
+	runNew,
+	runNewCommand,
+} from "@/commands/new";
 import { HetznerProvider } from "@/hetzner/provider";
 import type { Provider, SSHKeyManager } from "@/provider/interface";
 import type { VM } from "@/provider/types";
 import type { Session } from "@/session/types";
-import { baseProviderConfig } from "../../support/fixtures";
+import { agentModeConfig, baseProviderConfig } from "../../support/fixtures";
 
 type ProviderLike = Provider & SSHKeyManager;
 
@@ -54,7 +63,70 @@ function makeTimingSummary(
 	};
 }
 
+function makeExecChannel(stdout = "", stderr = "", exitCode = 0) {
+	const channel = new EventEmitter() as EventEmitter & {
+		stderr: EventEmitter;
+		write(chunk: string | Uint8Array): boolean;
+		end(): void;
+	};
+	channel.stderr = new EventEmitter();
+	channel.write = () => true;
+	channel.end = () => {};
+
+	setTimeout(() => {
+		if (stdout) channel.emit("data", stdout);
+		if (stderr) channel.stderr.emit("data", stderr);
+		channel.emit("close", exitCode);
+	}, 0);
+
+	return channel;
+}
+
 describe("commands/new", () => {
+	test("defaultWaitForCloudInit fails when cloud-init reports degraded status", async () => {
+		const commands: string[] = [];
+		let bootChecks = 0;
+
+		await expect(
+			defaultWaitForCloudInit(
+				agentModeConfig,
+				"203.0.113.10",
+				() => ({
+					connect: async () => {},
+					close: async () => {},
+					exec: async (command: string) => {
+						commands.push(command);
+						if (command === "test -f /var/lib/cloud/instance/boot-finished") {
+							bootChecks += 1;
+							return makeExecChannel("", "", bootChecks === 1 ? 0 : 1);
+						}
+						if (command === "cloud-init status --wait --long") {
+							return makeExecChannel(
+								"status: degraded done\nextended_status: degraded done\n",
+								"",
+								2,
+							);
+						}
+						if (command === "tail -n 200 /var/log/cloud-init-output.log") {
+							return makeExecChannel("template failed here\n", "", 0);
+						}
+						throw new Error(`unexpected command: ${command}`);
+					},
+					shell: async () => {
+						throw new Error("not used");
+					},
+					sftp: async () => {
+						throw new Error("not used");
+					},
+				}),
+				1000,
+			),
+		).rejects.toThrow("cloud-init reported a degraded state");
+
+		expect(commands).toContain("cloud-init status --wait --long");
+		expect(commands).toContain("tail -n 200 /var/log/cloud-init-output.log");
+	});
+
 	test("deletes VM and persists failed session when waitReady fails", async () => {
 		const deleted: string[] = [];
 		const added: Session[] = [];
@@ -181,6 +253,46 @@ describe("commands/new", () => {
 
 		expect(result.session.id).toBe("my-project");
 		expect(added[0].id).toBe("my-project");
+	});
+
+	test("copies git config without forcing GitHub https remotes to ssh", async () => {
+		const provider = makeProvider();
+		const root = await mkdtemp(join(tmpdir(), "sandctl-new-test-"));
+		const gitConfigPath = join(root, "gitconfig");
+		await writeFile(
+			gitConfigPath,
+			`[user]\n\tname = Chris\n\temail = chris@example.com\n`,
+		);
+
+		let writtenGitConfig = "";
+
+		await runNew(
+			{},
+			{
+				loadConfig: async () => ({
+					...baseProviderConfig,
+					ssh_key_source: "agent",
+					git_config_path: gitConfigPath,
+				}),
+				resolveProvider: () => provider,
+				generateSessionID: () => "violet",
+				getPublicKey: async () => "ssh-ed25519 AAAA test@local",
+				waitForCloudInit: async () => {},
+				setupGitConfig: async (config) => {
+					writtenGitConfig = await Bun.file(config.git_config_path!).text();
+				},
+				setupClaudeConfig: async () => {},
+				store: {
+					list: async () => [],
+					add: async () => {},
+					update: async () => {},
+				},
+			},
+		);
+
+		expect(writtenGitConfig).toContain("[user]");
+		expect(writtenGitConfig).not.toContain('url "ssh://git@github.com/"');
+		expect(writtenGitConfig).not.toContain("insteadOf = https://github.com/");
 	});
 
 	test("rejects invalid custom name", async () => {
@@ -842,6 +954,46 @@ describe("commands/new", () => {
 		expect(logs).not.toContain("Looking for matching snapshot...");
 	});
 
+	test("cache:false from commander also bypasses snapshot lookup", async () => {
+		let findSnapshotCalled = false;
+		const provider = makeProvider({
+			create: async () => ({
+				id: "vm-123",
+				name: "violet",
+				status: "running",
+				ipAddress: "203.0.113.10",
+				region: "ash",
+				serverType: "cpx31",
+				createdAt: "2026-02-22T00:00:00Z",
+			}),
+		});
+		(provider as ProviderLike & { findSnapshot?: () => Promise<{ id: string } | null> })
+			.findSnapshot = async () => {
+				findSnapshotCalled = true;
+				return { id: "123" };
+			};
+
+		await runNew(
+			{ cache: false },
+			{
+				loadConfig: async () => baseProviderConfig,
+				resolveProvider: () => provider,
+				generateSessionID: () => "violet",
+				getPublicKey: async () => "ssh-ed25519 AAAA test@local",
+				waitForCloudInit: async () => {},
+				setupGitConfig: async () => {},
+				setupClaudeConfig: async () => {},
+				store: {
+					list: async () => [],
+					add: async () => {},
+					update: async () => {},
+				},
+			},
+		);
+
+		expect(findSnapshotCalled).toBe(false);
+	});
+
 	test("runNew returns backgroundTasks for deferred snapshot creation on fresh boot", async () => {
 		const snapshotEvents: string[] = [];
 		const mockClient = {
@@ -1144,5 +1296,35 @@ describe("commands/new", () => {
 
 		// runNewCommand should have awaited backgroundTasks before returning
 		expect(order).toEqual(["background-done"]);
+	});
+
+	test("command wrapper forwards cache:false as noCache", async () => {
+		let receivedNoCache: boolean | undefined;
+
+		await runNewCommand({ cache: false }, undefined, {
+			runNew: async (options) => {
+				receivedNoCache = options.noCache;
+				return {
+					session: {
+						id: "violet",
+						status: "running",
+						provider: "hetzner",
+						provider_id: "vm-123",
+						ip_address: "203.0.113.10",
+						created_at: "2026-02-22T00:00:00Z",
+					},
+					timingSummary: makeTimingSummary(),
+				};
+			},
+			createSpinner: () => ({
+				succeed: () => {},
+				fail: () => {},
+				update: () => {},
+			}),
+			log: () => {},
+			warn: () => {},
+		});
+
+		expect(receivedNoCache).toBe(true);
 	});
 });

--- a/tests/unit/commands/new.test.ts
+++ b/tests/unit/commands/new.test.ts
@@ -5,8 +5,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
-	type NewResult,
 	defaultWaitForCloudInit,
+	type NewResult,
 	runNew,
 	runNewCommand,
 } from "@/commands/new";
@@ -967,11 +967,14 @@ describe("commands/new", () => {
 				createdAt: "2026-02-22T00:00:00Z",
 			}),
 		});
-		(provider as ProviderLike & { findSnapshot?: () => Promise<{ id: string } | null> })
-			.findSnapshot = async () => {
-				findSnapshotCalled = true;
-				return { id: "123" };
-			};
+		(
+			provider as ProviderLike & {
+				findSnapshot?: () => Promise<{ id: string } | null>;
+			}
+		).findSnapshot = async () => {
+			findSnapshotCalled = true;
+			return { id: "123" };
+		};
 
 		await runNew(
 			{ cache: false },

--- a/tests/unit/hetzner/setup.test.ts
+++ b/tests/unit/hetzner/setup.test.ts
@@ -16,6 +16,19 @@ describe("hetzner/setup", () => {
 			expect(output).toContain("sudo");
 		});
 
+		test("does not emit an empty ssh_authorized_keys list", () => {
+			const output = generateCloudInit();
+			expect(output).not.toContain("ssh_authorized_keys: []");
+		});
+
+		test("writes explicit passwordless sudoers entry for agent", () => {
+			const output = generateCloudInit();
+			expect(output).toContain(
+				"echo 'agent ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/99-agent",
+			);
+			expect(output).toContain("chmod 440 /etc/sudoers.d/99-agent");
+		});
+
 		test("copies SSH keys from root to agent user", () => {
 			const output = generateCloudInit();
 			expect(output).toContain(
@@ -75,6 +88,20 @@ describe("hetzner/setup", () => {
 			const output = generateCloudInit();
 			expect(output).toContain("apt-get install -y gh");
 			expect(output).toContain("githubcli-archive-keyring.gpg");
+		});
+
+		test("writes GitHub auth files when github token is provided", () => {
+			const output = generateCloudInit({ githubToken: "ghp_test_token" });
+			expect(output).toContain("/home/agent/.config/sandctl/github-token");
+			expect(output).toContain("/home/agent/.config/gh/hosts.yml");
+			expect(output).toContain("/etc/profile.d/sandctl-github-token.sh");
+			expect(output).toContain("chown -R agent:agent /home/agent/.config");
+		});
+
+		test("omits GitHub auth files when github token is absent", () => {
+			const output = generateCloudInit();
+			expect(output).not.toContain("/home/agent/.config/sandctl/github-token");
+			expect(output).not.toContain("/home/agent/.config/gh/hosts.yml");
 		});
 
 		test("overwrites interactive shell config in agent zshrc", () => {
@@ -141,13 +168,17 @@ describe("hetzner/setup", () => {
 		test("returns plain cloud-config when no additional layers", () => {
 			const base = "#cloud-config\nusers:\n  - name: agent\n";
 			const result = assembleUserData(base);
-			expect(result).toBe(base);
+			expect(result).toContain("SANDCTL BEGIN GLOBAL CLOUD-INIT");
+			expect(result).toContain("SANDCTL END GLOBAL CLOUD-INIT");
+			expect(result).toContain("name: agent");
 		});
 
 		test("returns plain cloud-config with empty layers array", () => {
 			const base = "#cloud-config\nusers:\n  - name: agent\n";
 			const result = assembleUserData(base, []);
-			expect(result).toBe(base);
+			expect(result).toContain("SANDCTL BEGIN GLOBAL CLOUD-INIT");
+			expect(result).toContain("SANDCTL END GLOBAL CLOUD-INIT");
+			expect(result).toContain("name: agent");
 		});
 
 		test("wraps in MIME multipart with one additional layer", () => {
@@ -165,6 +196,10 @@ describe("hetzner/setup", () => {
 			expect(result).toContain("Content-Type: text/x-shellscript");
 			expect(result).toContain("name: agent");
 			expect(result).toContain("echo hello");
+			expect(result).toContain("SANDCTL BEGIN GLOBAL CLOUD-INIT");
+			expect(result).toContain("SANDCTL END GLOBAL CLOUD-INIT");
+			expect(result).toContain("SANDCTL BEGIN LAYER 1");
+			expect(result).toContain("SANDCTL END LAYER 1");
 		});
 
 		test("wraps in MIME multipart with two additional layers", () => {
@@ -182,6 +217,9 @@ describe("hetzner/setup", () => {
 			).length;
 			expect(cloudConfigCount).toBe(2);
 			expect(shellscriptCount).toBe(1);
+			expect(result).toContain("SANDCTL BEGIN GLOBAL CLOUD-INIT");
+			expect(result).toContain("SANDCTL BEGIN LAYER 1");
+			expect(result).toContain("SANDCTL BEGIN LAYER 2");
 		});
 
 		test("normalizes content without trailing newline", () => {
@@ -200,7 +238,7 @@ describe("hetzner/setup", () => {
 			const result = assembleUserData(base, [layer]);
 
 			expect(result).toContain("merge_how:");
-			expect(result).toContain("settings: [append]");
+			expect(result).toContain("append");
 		});
 
 		test("does not inject merge_how into the global base", () => {
@@ -231,7 +269,7 @@ describe("hetzner/setup", () => {
 			// Should have exactly one merge_how (the user's own)
 			const count = (result.match(/merge_how:/g) || []).length;
 			expect(count).toBe(1);
-			expect(result).toContain("settings: [replace]");
+			expect(result).toContain("replace");
 		});
 	});
 });

--- a/tests/unit/hetzner/snapshots.test.ts
+++ b/tests/unit/hetzner/snapshots.test.ts
@@ -16,6 +16,7 @@ function makeImage(overrides: Partial<HetznerImage> = {}): HetznerImage {
 		type: "snapshot",
 		status: "available",
 		description: `sandctl-base-v${snapshotVersion(TEST_USER_DATA)}`,
+		created: "2026-04-12T00:00:00Z",
 		labels: { "managed-by": "sandctl", purpose: "base-image" },
 		created_from: { id: 1, name: "test-server" },
 		...overrides,
@@ -74,6 +75,20 @@ describe("hetzner/snapshots", () => {
 			const client = makeClient([image]);
 			const result = await findBaseSnapshot(client, TEST_USER_DATA);
 			expect(result).toEqual(image);
+		});
+
+		test("prefers newest matching snapshot when duplicates exist", async () => {
+			const older = makeImage({
+				id: 100,
+				created: "2026-04-12T00:00:00Z",
+			});
+			const newer = makeImage({
+				id: 200,
+				created: "2026-04-12T01:00:00Z",
+			});
+			const client = makeClient([older, newer]);
+			const result = await findBaseSnapshot(client, TEST_USER_DATA);
+			expect(result?.id).toBe(200);
 		});
 
 		test("ignores snapshots with wrong version", async () => {
@@ -142,6 +157,22 @@ describe("hetzner/snapshots", () => {
 			});
 			const current = makeImage({ id: 300 });
 			const client = makeClient([old, current]);
+
+			await cleanupOldSnapshots(client, TEST_USER_DATA);
+			expect(client.calls).toContain("deleteImage:200");
+			expect(client.calls).not.toContain("deleteImage:300");
+		});
+
+		test("deletes older duplicates of the current version", async () => {
+			const older = makeImage({
+				id: 200,
+				created: "2026-04-12T00:00:00Z",
+			});
+			const newer = makeImage({
+				id: 300,
+				created: "2026-04-12T01:00:00Z",
+			});
+			const client = makeClient([older, newer]);
 
 			await cleanupOldSnapshots(client, TEST_USER_DATA);
 			expect(client.calls).toContain("deleteImage:200");


### PR DESCRIPTION
## Summary

- Added DigitalOcean provider support alongside Hetzner, with provider-agnostic rename/resize capabilities and snapshot provisioning moved behind provider hooks
- Expanded live smoke CI into a provider matrix covering both Hetzner and DigitalOcean, with consolidated coverage and tuned sizing/region settings
- Hardened cloud-init provisioning: isolated agent tool install failures, added strict `cloud-init status` verification after boot-finished, fixed Codex install and probe flow
- Added layered cloud-init assembly with BEGIN/END banners per layer, GitHub token injection for the agent user, and paged output support in `sandctl logs`
- Kept the newest snapshot when multiple matches exist and imported missing provider VMs during `list` sync