### PR TITLE
Remove DigitalOcean provider from e2e tests, keep only Hetzner

### DIFF
--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -82,37 +82,18 @@ jobs:
         run: bun run test:e2e:contracts:ci
 
   e2e:
-    name: e2e (${{ matrix.provider }})
+    name: e2e (hetzner)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        provider: [hetzner, digitalocean]
     env:
       HETZNER_API_TOKEN: ${{ secrets.HETZNER_API_TOKEN }}
-      DIGITALOCEAN_API_TOKEN: ${{ secrets.DIGITALOCEAN_API_TOKEN }}
     steps:
       - name: Check secrets availability
         run: |
-          case "${{ matrix.provider }}" in
-            hetzner)
-              if [ -z "$HETZNER_API_TOKEN" ]; then
-                echo "::error::HETZNER_API_TOKEN is required for the Hetzner live smoke job."
-                exit 1
-              fi
-              ;;
-            digitalocean)
-              if [ -z "$DIGITALOCEAN_API_TOKEN" ]; then
-                echo "::error::DIGITALOCEAN_API_TOKEN is required for the DigitalOcean live smoke job."
-                exit 1
-              fi
-              ;;
-            *)
-              echo "::error::Unsupported live smoke provider: ${{ matrix.provider }}"
-              exit 1
-              ;;
-          esac
+          if [ -z "$HETZNER_API_TOKEN" ]; then
+            echo "::error::HETZNER_API_TOKEN is required for the Hetzner live smoke job."
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
@@ -123,31 +104,18 @@ jobs:
         run: ssh-keygen -t ed25519 -N '' -f /tmp/id_ed25519
       - name: Run live smoke E2E test
         env:
-          HETZNER_API_TOKEN_SECRET: ${{ env.HETZNER_API_TOKEN }}
-          DIGITALOCEAN_API_TOKEN_SECRET: ${{ env.DIGITALOCEAN_API_TOKEN }}
           SANDCTL_LIVE_SMOKE: "1"
           SSH_PUBLIC_KEY: /tmp/id_ed25519.pub
         shell: bash
         run: |
-          case "${{ matrix.provider }}" in
-            hetzner)
-              export HETZNER_API_TOKEN="$HETZNER_API_TOKEN_SECRET"
-              unset DIGITALOCEAN_API_TOKEN
-              ;;
-            digitalocean)
-              export DIGITALOCEAN_API_TOKEN="$DIGITALOCEAN_API_TOKEN_SECRET"
-              unset HETZNER_API_TOKEN
-              ;;
-          esac
-
-          bun test tests/e2e/live-smoke.test.ts 2>&1 | tee "/tmp/e2e-live-smoke-${{ matrix.provider }}.log"
+          bun test tests/e2e/live-smoke.test.ts 2>&1 | tee /tmp/e2e-live-smoke-hetzner.log
           exit ${PIPESTATUS[0]}
       - name: Upload e2e test logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-live-smoke-${{ matrix.provider }}-logs
-          path: /tmp/e2e-live-smoke-${{ matrix.provider }}.log
+          name: e2e-live-smoke-hetzner-logs
+          path: /tmp/e2e-live-smoke-hetzner.log
           retention-days: 7
       - name: Cleanup generated SSH key
         if: always()


### PR DESCRIPTION
## Summary
This PR simplifies the e2e test workflow by removing support for DigitalOcean as a cloud provider and consolidating on Hetzner as the sole provider for live smoke tests.

## Key Changes
- Removed the matrix strategy that ran e2e tests against both Hetzner and DigitalOcean providers
- Simplified the secrets availability check to only validate `HETZNER_API_TOKEN`
- Removed conditional logic that switched between provider-specific API tokens at runtime
- Removed `DIGITALOCEAN_API_TOKEN` environment variable from the workflow
- Updated artifact naming and logging to reference only Hetzner

## Implementation Details
- The job now runs as a single execution against Hetzner instead of a matrix with two parallel jobs
- Removed the case statement that handled provider-specific token setup and validation
- Simplified the test execution to directly run the e2e tests without provider-specific environment variable manipulation
- All hardcoded references to provider names in logs and artifacts now use "hetzner" exclusively

https://claude.ai/code/session_011y4m46h2ezLJ5h5tQRvRNM