### PR TITLE
Add GCP Compute Engine provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@
 # Required for e2e tests and sandctl operations
 HETZNER_API_TOKEN=your-hetzner-api-token-here
 DIGITALOCEAN_API_TOKEN=your-digitalocean-api-token-here
+GCP_PROJECT_ID=your-gcp-project-id-here
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 
 # Path to SSH public key (defaults to ~/.ssh/id_ed25519.pub if not set)
 SSH_PUBLIC_KEY=~/.ssh/id_ed25519.pub

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A CLI tool for managing sandboxed AI web development agents.
 
-sandctl provisions isolated VM environments on pluggable cloud providers. Hetzner Cloud and DigitalOcean are currently supported.
+sandctl provisions isolated VM environments on pluggable cloud providers. Hetzner Cloud, DigitalOcean, and GCP Compute Engine are currently supported.
 
 ## Prerequisites
 
@@ -22,13 +22,17 @@ Initialize a provider config:
 ```bash
 ./sandctl init --provider hetzner --hetzner-token <token> --ssh-agent
 ./sandctl init --provider digitalocean --digitalocean-token <token> --ssh-agent
+./sandctl init --provider gcp --gcp-project <project-id> --gcp-credentials-file <service-account.json> --ssh-agent
 ```
+
+For GCP, `--gcp-credentials-file` is optional when Application Default Credentials are configured in the environment.
 
 Create a VM with the configured default provider, or override it per command:
 
 ```bash
 ./sandctl new
 ./sandctl new --provider digitalocean --size large
+./sandctl new --provider gcp --region us-central1-a --size medium
 ```
 
 ## Build

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "sandctl",
       "dependencies": {
+        "@google-cloud/compute": "^4.11.0",
         "@inquirer/prompts": "^7.8.6",
         "async-lock": "^1.4.1",
         "chalk": "^5.5.0",
@@ -44,6 +45,12 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.4", "", { "os": "win32", "cpu": "x64" }, "sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A=="],
 
+    "@google-cloud/compute": ["@google-cloud/compute@4.12.0", "", { "dependencies": { "google-gax": "^4.0.3" } }, "sha512-N3isWbxIMd02qzdlFFxHxEM+2B/vNgn9N7WMpteY2sfwN1yT9PJHcilKDLyw+uIwuQAoErNxBM+JOLq3r/Tv+Q=="],
+
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
+
+    "@grpc/proto-loader": ["@grpc/proto-loader@0.7.15", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.2.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ=="],
+
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
     "@inquirer/checkbox": ["@inquirer/checkbox@4.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA=="],
@@ -76,9 +83,45 @@
 
     "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
 
+    "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+
+    "@tootallnate/once": ["@tootallnate/once@2.0.0", "", {}, "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="],
+
+    "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
+
+    "@types/long": ["@types/long@4.0.2", "", {}, "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="],
+
     "@types/node": ["@types/node@24.10.13", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg=="],
 
+    "@types/request": ["@types/request@2.48.13", "", { "dependencies": { "@types/caseless": "*", "@types/node": "*", "@types/tough-cookie": "*", "form-data": "^2.5.5" } }, "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg=="],
+
     "@types/ssh2": ["@types/ssh2@1.15.5", "", { "dependencies": { "@types/node": "^18.11.18" } }, "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ=="],
+
+    "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -88,11 +131,21 @@
 
     "async-lock": ["async-lock@1.4.1", "", {}, "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -100,21 +153,107 @@
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "cpu-features": ["cpu-features@0.0.10", "", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
 
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gaxios": ["gaxios@6.7.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "is-stream": "^2.0.0", "node-fetch": "^2.6.9", "uuid": "^9.0.1" } }, "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ=="],
+
+    "gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
+
+    "google-gax": ["google-gax@4.6.1", "", { "dependencies": { "@grpc/grpc-js": "^1.10.9", "@grpc/proto-loader": "^0.7.13", "@types/long": "^4.0.0", "abort-controller": "^3.0.0", "duplexify": "^4.0.0", "google-auth-library": "^9.3.0", "node-fetch": "^2.7.0", "object-hash": "^3.0.0", "proto3-json-serializer": "^2.0.2", "protobufjs": "^7.3.2", "retry-request": "^7.0.0", "uuid": "^9.0.1" } }, "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ=="],
+
+    "google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
@@ -122,7 +261,25 @@
 
     "nanospinner": ["nanospinner@1.2.2", "", { "dependencies": { "picocolors": "^1.1.1" } }, "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "proto3-json-serializer": ["proto3-json-serializer@2.0.2", "", { "dependencies": { "protobufjs": "^7.2.5" } }, "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ=="],
+
+    "protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "retry-request": ["retry-request@7.0.2", "", { "dependencies": { "@types/request": "^2.48.8", "extend": "^3.0.2", "teeny-request": "^9.0.0" } }, "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -130,9 +287,21 @@
 
     "ssh2": ["ssh2@1.17.0", "", { "dependencies": { "asn1": "^0.2.6", "bcrypt-pbkdf": "^1.0.2" }, "optionalDependencies": { "cpu-features": "~0.0.10", "nan": "^2.23.0" } }, "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ=="],
 
+    "stream-events": ["stream-events@1.0.5", "", { "dependencies": { "stubs": "^3.0.0" } }, "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg=="],
+
+    "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
+
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "stubs": ["stubs@3.0.0", "", {}, "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="],
+
+    "teeny-request": ["teeny-request@9.0.0", "", { "dependencies": { "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.9", "stream-events": "^1.0.5", "uuid": "^9.0.0" } }, "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 
@@ -140,18 +309,44 @@
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
     "validator": ["validator@13.15.26", "", {}, "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
+
     "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "http-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "teeny-request/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
     "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "teeny-request/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"check-fmt": "biome format src/ tests/"
 	},
 	"dependencies": {
+		"@google-cloud/compute": "^4.11.0",
 		"@inquirer/prompts": "^7.8.6",
 		"async-lock": "^1.4.1",
 		"chalk": "^5.5.0",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,12 +10,14 @@ import { save } from "@/config/writer";
 import { isValidEmail } from "@/utils/email";
 import { expandTilde } from "@/utils/paths";
 
-type SupportedProvider = "digitalocean" | "hetzner";
+type SupportedProvider = "digitalocean" | "gcp" | "hetzner";
 
 interface InitOptions {
 	provider?: string;
 	hetznerToken?: string;
 	digitaloceanToken?: string;
+	gcpProject?: string;
+	gcpCredentialsFile?: string;
 	sshPublicKey?: string;
 	sshAgent?: boolean;
 	sshKeyFingerprint?: string;
@@ -67,6 +69,41 @@ const PROVIDER_METADATA = {
 			},
 		],
 	},
+	gcp: {
+		defaultRegion: "us-central1-a",
+		defaultServerType: "e2-standard-4",
+		defaultImage:
+			"projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64",
+		tokenField: undefined,
+		tokenFlag: "--gcp-project",
+		tokenLabel: "GCP project ID",
+		regionChoices: [
+			{ name: "Iowa, US (us-central1-a)", value: "us-central1-a" },
+			{ name: "South Carolina, US (us-east1-b)", value: "us-east1-b" },
+			{ name: "Oregon, US (us-west1-a)", value: "us-west1-a" },
+			{ name: "London, UK (europe-west2-a)", value: "europe-west2-a" },
+			{ name: "Frankfurt, Germany (europe-west3-a)", value: "europe-west3-a" },
+			{ name: "Singapore (asia-southeast1-a)", value: "asia-southeast1-a" },
+		],
+		serverTypeChoices: [
+			{
+				name: "E2 standard 2 vCPU, 8 GB RAM (e2-standard-2)",
+				value: "e2-standard-2",
+			},
+			{
+				name: "E2 standard 4 vCPU, 16 GB RAM (e2-standard-4)",
+				value: "e2-standard-4",
+			},
+			{
+				name: "E2 standard 8 vCPU, 32 GB RAM (e2-standard-8)",
+				value: "e2-standard-8",
+			},
+			{
+				name: "E2 standard 16 vCPU, 64 GB RAM (e2-standard-16)",
+				value: "e2-standard-16",
+			},
+		],
+	},
 	hetzner: {
 		defaultRegion: "ash",
 		defaultServerType: "cpx31",
@@ -112,14 +149,23 @@ function resolveProvider(
 	provider?: string,
 	options?: InitOptions,
 ): SupportedProvider {
-	if (options?.hetznerToken && options.digitaloceanToken) {
+	const tokenProviderFlags = [
+		options?.hetznerToken ? "hetzner" : undefined,
+		options?.digitaloceanToken ? "digitalocean" : undefined,
+		options?.gcpProject ? "gcp" : undefined,
+	].filter(Boolean);
+	if (tokenProviderFlags.length > 1) {
 		throw new Error(
-			"--hetzner-token and --digitalocean-token cannot be used together",
+			"--hetzner-token, --digitalocean-token, and --gcp-project cannot be used together",
 		);
 	}
 
 	if (provider) {
-		if (provider === "hetzner" || provider === "digitalocean") {
+		if (
+			provider === "hetzner" ||
+			provider === "digitalocean" ||
+			provider === "gcp"
+		) {
 			return provider;
 		}
 		throw new Error(`unsupported provider '${provider}'`);
@@ -127,6 +173,9 @@ function resolveProvider(
 
 	if (options?.digitaloceanToken) {
 		return "digitalocean";
+	}
+	if (options?.gcpProject) {
+		return "gcp";
 	}
 
 	return "hetzner";
@@ -136,7 +185,23 @@ function providerToken(
 	provider: SupportedProvider,
 	options: InitOptions,
 ): string | undefined {
-	return options[PROVIDER_METADATA[provider].tokenField];
+	const tokenField = PROVIDER_METADATA[provider].tokenField;
+	return tokenField ? options[tokenField] : undefined;
+}
+
+function hasProviderCredential(
+	provider: SupportedProvider,
+	options: InitOptions,
+): boolean {
+	if (provider === "gcp") {
+		return Boolean(options.gcpProject);
+	}
+	return Boolean(providerToken(provider, options));
+}
+
+function optionalText(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
 }
 
 export interface InitResult {
@@ -186,10 +251,9 @@ export async function runInit(
 
 	const selectedProvider = resolveProvider(options.provider, options);
 	const selectedProviderMeta = PROVIDER_METADATA[selectedProvider];
-	const selectedToken = providerToken(selectedProvider, options);
 
 	const hasNonInteractiveFlags =
-		Boolean(selectedToken) ||
+		hasProviderCredential(selectedProvider, options) ||
 		Boolean(options.sshAgent) ||
 		Boolean(options.sshPublicKey);
 
@@ -203,7 +267,7 @@ export async function runInit(
 	}
 
 	if (hasNonInteractiveFlags) {
-		if (!selectedToken) {
+		if (!hasProviderCredential(selectedProvider, options)) {
 			throw new Error(
 				`${selectedProviderMeta.tokenFlag} is required in non-interactive mode`,
 			);
@@ -229,22 +293,43 @@ export async function runInit(
 	const provider = await select<SupportedProvider>({
 		message: "Default provider",
 		default:
-			existing?.default_provider === "digitalocean"
-				? "digitalocean"
+			existing?.default_provider === "digitalocean" ||
+			existing?.default_provider === "gcp"
+				? existing.default_provider
 				: "hetzner",
 		theme: VIM_SELECT_THEME,
 		choices: [
 			{ name: "Hetzner", value: "hetzner" },
 			{ name: "DigitalOcean", value: "digitalocean" },
+			{ name: "GCP Compute Engine", value: "gcp" },
 		],
 	});
 	const providerMeta = PROVIDER_METADATA[provider];
 
-	const token =
-		(await password({
-			message: `${providerMeta.tokenLabel}${existing?.providers?.[provider]?.token ? " (leave blank to keep existing)" : ""}`,
-			mask: true,
-		})) || existing?.providers?.[provider]?.token;
+	let token: string | undefined;
+	let gcpProject: string | undefined;
+	let gcpCredentialsFile: string | undefined;
+	if (provider === "gcp") {
+		gcpProject = optionalText(
+			await input({
+				message: `${providerMeta.tokenLabel}${existing?.providers?.gcp?.project_id ? " (leave blank to keep existing)" : ""}`,
+				default: existing?.providers?.gcp?.project_id,
+			}),
+		);
+		gcpCredentialsFile = optionalText(
+			await input({
+				message:
+					"GCP service-account credentials file (optional; blank uses ADC)",
+				default: existing?.providers?.gcp?.credentials_file,
+			}),
+		);
+	} else {
+		token =
+			(await password({
+				message: `${providerMeta.tokenLabel}${existing?.providers?.[provider]?.token ? " (leave blank to keep existing)" : ""}`,
+				mask: true,
+			})) || existing?.providers?.[provider]?.token;
+	}
 
 	const sshMode = await select({
 		message: "SSH key mode",
@@ -394,8 +479,12 @@ export async function runInit(
 		githubToken,
 		claudeConfigPath,
 		claudeOauthToken,
+		gcpProject,
+		gcpCredentialsFile,
 	};
-	interactiveOptions[providerMeta.tokenField] = token;
+	if (provider !== "gcp" && providerMeta.tokenField) {
+		interactiveOptions[providerMeta.tokenField] = token;
+	}
 
 	await save(
 		resolvedConfigPath,
@@ -431,7 +520,16 @@ function buildConfig(
 			...(existing?.providers ?? {}),
 			[provider]: {
 				...(existing?.providers?.[provider] ?? {}),
-				token: token ?? "",
+				token: provider === "gcp" ? undefined : (token ?? ""),
+				project_id:
+					provider === "gcp"
+						? (options.gcpProject ?? existing?.providers?.gcp?.project_id)
+						: undefined,
+				credentials_file:
+					provider === "gcp"
+						? (options.gcpCredentialsFile ??
+							existing?.providers?.gcp?.credentials_file)
+						: undefined,
 				region:
 					options.region ??
 					existing?.providers?.[provider]?.region ??
@@ -460,10 +558,15 @@ export function registerInitCommand(): Command {
 		.description("Initialize sandctl configuration")
 		.option(
 			"--provider <provider>",
-			"Default provider (hetzner or digitalocean)",
+			"Default provider (hetzner, digitalocean, or gcp)",
 		)
 		.option("--hetzner-token <token>", "Hetzner Cloud API token")
 		.option("--digitalocean-token <token>", "DigitalOcean API token")
+		.option("--gcp-project <project>", "GCP project ID")
+		.option(
+			"--gcp-credentials-file <path>",
+			"GCP service-account credentials JSON file (optional; defaults to ADC)",
+		)
 		.option("--ssh-public-key <path>", "Path to SSH public key file")
 		.option("--ssh-agent", "Use SSH agent for key management")
 		.option("--ssh-key-fingerprint <fingerprint>", "SSH key fingerprint")
@@ -488,14 +591,15 @@ export function registerInitCommand(): Command {
 			};
 			if (globals.json) {
 				const hasNonInteractiveFlags =
-					Boolean(
-						providerToken(resolveProvider(options.provider, options), options),
+					hasProviderCredential(
+						resolveProvider(options.provider, options),
+						options,
 					) ||
 					Boolean(options.sshAgent) ||
 					Boolean(options.sshPublicKey);
 				if (!hasNonInteractiveFlags) {
 					throw new Error(
-						"--json requires non-interactive flags (provider token with --ssh-agent or --ssh-public-key)",
+						"--json requires non-interactive flags (provider credentials with --ssh-agent or --ssh-public-key)",
 					);
 				}
 			}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -10,11 +10,15 @@ import { isValidEmail } from "@/utils/email";
 import { expandTilde } from "@/utils/paths";
 
 export interface ProviderConfig {
-	token: string;
+	token?: string;
 	region?: string;
 	server_type?: string;
 	image?: string;
 	ssh_key_id?: number;
+	project_id?: string;
+	credentials_file?: string;
+	disk_size_gb?: number;
+	network?: string;
 }
 
 export interface Config {

--- a/src/digitalocean/provider.ts
+++ b/src/digitalocean/provider.ts
@@ -77,7 +77,7 @@ export class DigitalOceanProvider
 		) => Promise<boolean> = defaultProbeTCP,
 		private readonly now: () => number = () => performance.now(),
 	) {
-		this.client = client ?? new DigitalOceanClient(config.token);
+		this.client = client ?? new DigitalOceanClient(config.token ?? "");
 	}
 
 	name(): string {

--- a/src/gcp/provider.ts
+++ b/src/gcp/provider.ts
@@ -1,0 +1,585 @@
+import { Socket } from "node:net";
+import * as compute from "@google-cloud/compute";
+import type { ProviderConfig } from "@/config/config";
+import {
+	ErrAuthFailed,
+	ErrNotFound,
+	ErrProvisionFailed,
+	ErrQuotaExceeded,
+	ErrTimeout,
+} from "@/provider/errors";
+import type { Provider, SSHKeyManager } from "@/provider/interface";
+import type { CreateOpts, VM, VMStatus } from "@/provider/types";
+import { expandTilde } from "@/utils/paths";
+
+const PROVIDER_NAME = "gcp";
+const DEFAULT_ZONE = "us-central1-a";
+const DEFAULT_MACHINE_TYPE = "e2-standard-4";
+const DEFAULT_IMAGE =
+	"projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64";
+const DEFAULT_DISK_SIZE_GB = 50;
+const DEFAULT_NETWORK = "global/networks/default";
+const MANAGED_LABEL_KEY = "managed-by";
+const MANAGED_LABEL_VALUE = "sandctl";
+const POLL_INTERVAL_MS = 5_000;
+const SSH_PORT = 22;
+const SSH_PROBE_TIMEOUT_MS = 2_000;
+const SSH_PROBE_RETRIES = 3;
+const SSH_RETRY_DELAY_MS = 1_000;
+
+type GcpOperation = {
+	name?: string | null;
+	status?: string | null;
+	zone?: string | null;
+	error?: {
+		errors?: Array<{ message?: string | null }>;
+	};
+};
+
+export interface GcpInstance {
+	id?: string | number | null;
+	name?: string | null;
+	status?: string | null;
+	creationTimestamp?: string | null;
+	zone?: string | null;
+	machineType?: string | null;
+	networkInterfaces?: Array<{
+		networkIP?: string | null;
+		accessConfigs?: Array<{ natIP?: string | null }>;
+	}>;
+	disks?: Array<{
+		boot?: boolean | null;
+		diskSizeGb?: string | number | null;
+	}>;
+}
+
+export interface GcpClientLike {
+	insertInstance(opts: {
+		project: string;
+		zone: string;
+		instanceResource: Record<string, unknown>;
+	}): Promise<GcpOperation>;
+	getInstance(
+		project: string,
+		zone: string,
+		name: string,
+	): Promise<GcpInstance>;
+	deleteInstance(
+		project: string,
+		zone: string,
+		name: string,
+	): Promise<GcpOperation>;
+	resetInstance(
+		project: string,
+		zone: string,
+		name: string,
+	): Promise<GcpOperation>;
+	listInstances(
+		project: string,
+		zone: string,
+		filter?: string,
+	): Promise<GcpInstance[]>;
+	waitZoneOperation(
+		project: string,
+		zone: string,
+		operation: string,
+	): Promise<GcpOperation>;
+}
+
+export class GcpProvider implements Provider, SSHKeyManager {
+	readonly client: GcpClientLike;
+
+	constructor(
+		private readonly config: ProviderConfig,
+		client?: GcpClientLike,
+		private readonly sleep: (ms: number) => Promise<void> = (ms) =>
+			new Promise((resolve) => setTimeout(resolve, ms)),
+		private readonly probeTCP: (
+			host: string,
+			port: number,
+			timeoutMs: number,
+		) => Promise<boolean> = defaultProbeTCP,
+		private readonly now: () => number = () => performance.now(),
+	) {
+		this.client = client ?? new GcpComputeClient(config);
+	}
+
+	name(): string {
+		return PROVIDER_NAME;
+	}
+
+	async create(opts: CreateOpts): Promise<VM> {
+		const project = this.projectID();
+		const zone = opts.region ?? this.config.region ?? DEFAULT_ZONE;
+		const machineType =
+			opts.serverType ?? this.config.server_type ?? DEFAULT_MACHINE_TYPE;
+		const image = opts.image ?? this.config.image ?? DEFAULT_IMAGE;
+		const metadataItems = metadataItemsForCreate(opts);
+
+		const operation = await this.client.insertInstance({
+			project,
+			zone,
+			instanceResource: {
+				name: opts.name,
+				labels: {
+					[MANAGED_LABEL_KEY]: MANAGED_LABEL_VALUE,
+				},
+				disks: [
+					{
+						autoDelete: true,
+						boot: true,
+						type: "PERSISTENT",
+						initializeParams: {
+							diskSizeGb: String(
+								this.config.disk_size_gb ?? DEFAULT_DISK_SIZE_GB,
+							),
+							sourceImage: image,
+						},
+					},
+				],
+				machineType: `zones/${zone}/machineTypes/${machineType}`,
+				networkInterfaces: [
+					{
+						name: this.config.network ?? DEFAULT_NETWORK,
+						accessConfigs: [{ name: "External NAT", type: "ONE_TO_ONE_NAT" }],
+					},
+				],
+				...(metadataItems.length > 0
+					? { metadata: { items: metadataItems } }
+					: {}),
+			},
+		});
+		await this.waitForOperation(project, zone, operation);
+		return mapInstance(
+			await this.client.getInstance(project, zone, opts.name),
+			zone,
+		);
+	}
+
+	async get(id: string): Promise<VM> {
+		const { zone, name } = this.parseInstanceID(id);
+		return mapInstance(
+			await this.client.getInstance(this.projectID(), zone, name),
+			zone,
+		);
+	}
+
+	async delete(id: string): Promise<void> {
+		const project = this.projectID();
+		const { zone, name } = this.parseInstanceID(id);
+		try {
+			const operation = await this.client.deleteInstance(project, zone, name);
+			await this.waitForOperation(project, zone, operation);
+		} catch (error) {
+			if (error instanceof ErrNotFound) {
+				return;
+			}
+			throw error;
+		}
+	}
+
+	async reboot(id: string): Promise<void> {
+		const project = this.projectID();
+		const { zone, name } = this.parseInstanceID(id);
+		const operation = await this.client.resetInstance(project, zone, name);
+		await this.waitForOperation(project, zone, operation);
+	}
+
+	async list(): Promise<VM[]> {
+		const zone = this.config.region ?? DEFAULT_ZONE;
+		const instances = await this.client.listInstances(
+			this.projectID(),
+			zone,
+			`labels.${MANAGED_LABEL_KEY} = ${MANAGED_LABEL_VALUE}`,
+		);
+		return instances.map((instance) => mapInstance(instance, zone));
+	}
+
+	async waitReady(id: string, timeoutMs: number): Promise<void> {
+		const deadline = this.now() + timeoutMs;
+		const remaining = (): number => deadline - this.now();
+
+		while (remaining() > 0) {
+			let vm: VM;
+			try {
+				vm = await this.get(id);
+			} catch (error: unknown) {
+				if (error instanceof ErrNotFound) {
+					throw new ErrProvisionFailed(`vm not found while waiting: ${id}`);
+				}
+
+				const delay = Math.min(POLL_INTERVAL_MS, Math.max(0, remaining()));
+				if (delay <= 0) {
+					break;
+				}
+
+				await this.sleep(delay);
+				continue;
+			}
+
+			if (vm.status === "failed") {
+				throw new ErrProvisionFailed(`vm entered failed state: ${id}`);
+			}
+
+			if (vm.status === "running" && vm.ipAddress) {
+				const sshReady = await this.waitForSSH(vm.ipAddress, deadline);
+				if (sshReady) {
+					return;
+				}
+			}
+
+			const delay = Math.min(POLL_INTERVAL_MS, Math.max(0, remaining()));
+			if (delay <= 0) {
+				break;
+			}
+			await this.sleep(delay);
+		}
+
+		throw new ErrTimeout(`timed out waiting for vm ${id} to become ready`);
+	}
+
+	async ensureSSHKey(_name: string, publicKey: string): Promise<string> {
+		return publicKey.trim();
+	}
+
+	private projectID(): string {
+		if (!this.config.project_id) {
+			throw new Error("gcp provider requires project_id");
+		}
+		return this.config.project_id;
+	}
+
+	private parseInstanceID(id: string): { zone: string; name: string } {
+		const [zone, name] = id.includes("/")
+			? id.split("/", 2)
+			: [this.config.region ?? DEFAULT_ZONE, id];
+		return { zone, name };
+	}
+
+	private async waitForOperation(
+		project: string,
+		zone: string,
+		operation: GcpOperation,
+	): Promise<void> {
+		if (!operation.name) {
+			return;
+		}
+
+		let current = operation;
+		while (current.status !== "DONE") {
+			current = await this.client.waitZoneOperation(
+				project,
+				zone,
+				operation.name,
+			);
+		}
+
+		const message = current.error?.errors
+			?.map((err) => err.message)
+			.filter(Boolean)
+			.join("; ");
+		if (message) {
+			throw new ErrProvisionFailed(message);
+		}
+	}
+
+	private async waitForSSH(host: string, deadline: number): Promise<boolean> {
+		for (let attempt = 0; attempt < SSH_PROBE_RETRIES; attempt++) {
+			const probeBudget = deadline - this.now();
+			if (probeBudget <= 0) {
+				return false;
+			}
+
+			const timeout = Math.min(SSH_PROBE_TIMEOUT_MS, probeBudget);
+			if (await this.probeTCP(host, SSH_PORT, timeout)) {
+				if (this.now() > deadline) {
+					return false;
+				}
+				return true;
+			}
+
+			if (attempt === SSH_PROBE_RETRIES - 1) {
+				break;
+			}
+
+			const retryBudget = deadline - this.now();
+			if (retryBudget <= 0) {
+				break;
+			}
+
+			await this.sleep(Math.min(SSH_RETRY_DELAY_MS, retryBudget));
+		}
+
+		return false;
+	}
+}
+
+class GcpComputeClient implements GcpClientLike {
+	private readonly instancesClient: InstanceClientApi;
+	private readonly operationsClient: ZoneOperationsClientApi;
+
+	constructor(config: ProviderConfig) {
+		const clientOptions = config.credentials_file
+			? { keyFilename: expandTilde(config.credentials_file) }
+			: undefined;
+		const computeModule = compute as unknown as {
+			InstancesClient: new (
+				opts?: Record<string, unknown>,
+			) => InstanceClientApi;
+			ZoneOperationsClient: new (
+				opts?: Record<string, unknown>,
+			) => ZoneOperationsClientApi;
+		};
+		this.instancesClient = new computeModule.InstancesClient(clientOptions);
+		this.operationsClient = new computeModule.ZoneOperationsClient(
+			clientOptions,
+		);
+	}
+
+	async insertInstance(opts: {
+		project: string;
+		zone: string;
+		instanceResource: Record<string, unknown>;
+	}): Promise<GcpOperation> {
+		return unwrapOperation(
+			await this.call(() => this.instancesClient.insert(opts)),
+		);
+	}
+
+	async getInstance(
+		project: string,
+		zone: string,
+		name: string,
+	): Promise<GcpInstance> {
+		const [instance] = await this.call(() =>
+			this.instancesClient.get({ project, zone, instance: name }),
+		);
+		return instance as GcpInstance;
+	}
+
+	async deleteInstance(
+		project: string,
+		zone: string,
+		name: string,
+	): Promise<GcpOperation> {
+		return unwrapOperation(
+			await this.call(() =>
+				this.instancesClient.delete({ project, zone, instance: name }),
+			),
+		);
+	}
+
+	async resetInstance(
+		project: string,
+		zone: string,
+		name: string,
+	): Promise<GcpOperation> {
+		return unwrapOperation(
+			await this.call(() =>
+				this.instancesClient.reset({ project, zone, instance: name }),
+			),
+		);
+	}
+
+	async listInstances(
+		project: string,
+		zone: string,
+		filter?: string,
+	): Promise<GcpInstance[]> {
+		const [instances] = await this.call(() =>
+			this.instancesClient.list({ project, zone, filter }),
+		);
+		return (instances ?? []) as GcpInstance[];
+	}
+
+	async waitZoneOperation(
+		project: string,
+		zone: string,
+		operation: string,
+	): Promise<GcpOperation> {
+		const [result] = await this.call(() =>
+			this.operationsClient.wait({ project, zone, operation }),
+		);
+		return result as GcpOperation;
+	}
+
+	private async call<T>(fn: () => Promise<T>): Promise<T> {
+		try {
+			return await fn();
+		} catch (error) {
+			throw mapGcpError(error);
+		}
+	}
+}
+
+interface InstanceClientApi {
+	insert(opts: Record<string, unknown>): Promise<unknown[]>;
+	get(opts: Record<string, unknown>): Promise<unknown[]>;
+	delete(opts: Record<string, unknown>): Promise<unknown[]>;
+	reset(opts: Record<string, unknown>): Promise<unknown[]>;
+	list(opts: Record<string, unknown>): Promise<unknown[]>;
+}
+
+interface ZoneOperationsClientApi {
+	wait(opts: Record<string, unknown>): Promise<unknown[]>;
+}
+
+function metadataItemsForCreate(
+	opts: CreateOpts,
+): Array<{ key: string; value: string }> {
+	const items: Array<{ key: string; value: string }> = [];
+
+	if (opts.sshKeyIDs?.length) {
+		items.push({
+			key: "ssh-keys",
+			value: opts.sshKeyIDs.map((key) => `agent:${key}`).join("\n"),
+		});
+	}
+
+	if (!opts.skipUserData && opts.userData) {
+		items.push({ key: "user-data", value: opts.userData });
+	}
+
+	return items;
+}
+
+function unwrapOperation(response: unknown[]): GcpOperation {
+	const first = response[0] as { latestResponse?: GcpOperation } | GcpOperation;
+	const maybeWrapped = first as { latestResponse?: GcpOperation };
+	if (maybeWrapped.latestResponse !== undefined) {
+		return maybeWrapped.latestResponse;
+	}
+	return first as GcpOperation;
+}
+
+function mapGcpError(error: unknown): Error {
+	const code =
+		typeof error === "object" && error
+			? (error as { code?: number }).code
+			: undefined;
+	const message =
+		error instanceof Error
+			? error.message
+			: `gcp api request failed: ${String(error)}`;
+
+	if (code === 5) {
+		return new ErrNotFound(message);
+	}
+	if (code === 7 || code === 16) {
+		return new ErrAuthFailed(message);
+	}
+	if (code === 8) {
+		return new ErrQuotaExceeded(message);
+	}
+	return new ErrProvisionFailed(
+		message,
+		error instanceof Error ? { cause: error } : undefined,
+	);
+}
+
+async function defaultProbeTCP(
+	host: string,
+	port: number,
+	timeoutMs: number,
+): Promise<boolean> {
+	if (timeoutMs <= 0) {
+		return false;
+	}
+
+	return await new Promise<boolean>((resolve) => {
+		const socket = new Socket();
+		let settled = false;
+
+		const finish = (result: boolean): void => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			socket.destroy();
+			resolve(result);
+		};
+
+		socket.once("connect", () => finish(true));
+		socket.once("timeout", () => finish(false));
+		socket.once("error", () => finish(false));
+		socket.setTimeout(timeoutMs);
+		socket.connect(port, host);
+	});
+}
+
+function mapStatus(status?: string | null): VMStatus {
+	switch (status) {
+		case "PROVISIONING":
+		case "STAGING":
+			return "provisioning";
+		case "RUNNING":
+			return "running";
+		case "STOPPING":
+		case "SUSPENDING":
+			return "stopping";
+		case "TERMINATED":
+		case "SUSPENDED":
+			return "stopped";
+		default:
+			return "failed";
+	}
+}
+
+function basename(selfLink?: string | null): string | undefined {
+	return selfLink?.split("/").filter(Boolean).at(-1);
+}
+
+function publicIPv4(instance: GcpInstance): string | null {
+	return (
+		instance.networkInterfaces
+			?.find((network) => network.accessConfigs?.length)
+			?.accessConfigs?.find((config) => config.natIP)?.natIP ?? null
+	);
+}
+
+function bootDiskGB(instance: GcpInstance): number | undefined {
+	const value = instance.disks?.find((disk) => disk.boot)?.diskSizeGb;
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function mapInstance(instance: GcpInstance, fallbackZone: string): VM {
+	const serverType = basename(instance.machineType) ?? DEFAULT_MACHINE_TYPE;
+	const zone = basename(instance.zone) ?? fallbackZone;
+	const name = instance.name ?? String(instance.id ?? "");
+
+	return {
+		id: `${zone}/${name}`,
+		name,
+		status: mapStatus(instance.status),
+		ipAddress: publicIPv4(instance),
+		region: zone,
+		serverType,
+		createdAt: instance.creationTimestamp ?? new Date(0).toISOString(),
+		cores: machineTypeCores(serverType),
+		memoryGB: machineTypeMemoryGB(serverType),
+		diskGB: bootDiskGB(instance),
+	};
+}
+
+function machineTypeCores(machineType: string): number | undefined {
+	const match = /-(\d+)$/.exec(machineType);
+	return match ? Number(match[1]) : undefined;
+}
+
+function machineTypeMemoryGB(machineType: string): number | undefined {
+	const cores = machineTypeCores(machineType);
+	if (cores === undefined) {
+		return undefined;
+	}
+	if (machineType.startsWith("e2-highmem-")) {
+		return cores * 8;
+	}
+	if (machineType.startsWith("e2-highcpu-")) {
+		return cores;
+	}
+	return cores * 4;
+}

--- a/src/hetzner/provider.ts
+++ b/src/hetzner/provider.ts
@@ -83,7 +83,7 @@ export class HetznerProvider
 		) => Promise<boolean> = defaultProbeTCP,
 		private readonly now: () => number = () => performance.now(),
 	) {
-		this.client = client ?? new HetznerClient(config.token);
+		this.client = client ?? new HetznerClient(config.token ?? "");
 	}
 
 	name(): string {

--- a/src/provider/registry.ts
+++ b/src/provider/registry.ts
@@ -1,5 +1,6 @@
 import type { ProviderConfig } from "@/config/config";
 import { DigitalOceanProvider } from "@/digitalocean/provider";
+import { GcpProvider } from "@/gcp/provider";
 import { HetznerProvider } from "@/hetzner/provider";
 import { ErrUnknownProvider } from "@/provider/errors";
 import type { Provider, SSHKeyManager } from "@/provider/interface";
@@ -43,6 +44,7 @@ export function registerBuiltinProviders(): void {
 	}
 
 	register("digitalocean", (config) => new DigitalOceanProvider(config));
+	register("gcp", (config) => new GcpProvider(config));
 	register("hetzner", (config) => new HetznerProvider(config));
 	builtinsRegistered = true;
 }

--- a/src/provider/sizes.ts
+++ b/src/provider/sizes.ts
@@ -54,6 +54,48 @@ const sizeMaps = {
 			},
 		],
 	]),
+	gcp: new Map<string, VMSize>([
+		[
+			"small",
+			{
+				name: "small",
+				serverType: "e2-standard-2",
+				cores: 2,
+				memoryGB: 8,
+				description: "2 vCPU / 8 GB RAM",
+			},
+		],
+		[
+			"medium",
+			{
+				name: "medium",
+				serverType: "e2-standard-4",
+				cores: 4,
+				memoryGB: 16,
+				description: "4 vCPU / 16 GB RAM",
+			},
+		],
+		[
+			"large",
+			{
+				name: "large",
+				serverType: "e2-standard-8",
+				cores: 8,
+				memoryGB: 32,
+				description: "8 vCPU / 32 GB RAM",
+			},
+		],
+		[
+			"xlarge",
+			{
+				name: "xlarge",
+				serverType: "e2-standard-16",
+				cores: 16,
+				memoryGB: 64,
+				description: "16 vCPU / 64 GB RAM",
+			},
+		],
+	]),
 	hetzner: new Map<string, VMSize>([
 		[
 			"small",

--- a/tests/unit/commands/init.test.ts
+++ b/tests/unit/commands/init.test.ts
@@ -128,6 +128,55 @@ describe("init command (non-interactive)", () => {
 		}
 	});
 
+	test("writes GCP config when selected", async () => {
+		const tmpDir = mkdtempSync(path.join(os.tmpdir(), "sandctl-ts-init-"));
+		try {
+			const configPath = path.join(tmpDir, "config.yaml");
+
+			await runInit(
+				{
+					provider: "gcp",
+					gcpProject: "sandctl-test-project",
+					gcpCredentialsFile: "/tmp/gcp-creds.json",
+					sshAgent: true,
+					region: "us-east1-b",
+					serverType: "e2-standard-8",
+				},
+				configPath,
+			);
+
+			const config = parse(readFileSync(configPath, "utf8")) as Record<
+				string,
+				unknown
+			>;
+			const gcpConfig = (
+				config.providers as Record<
+					string,
+					{ project_id: string; credentials_file: string; token?: string }
+				>
+			).gcp;
+
+			expect(config.default_provider).toBe("gcp");
+			expect(gcpConfig.project_id).toBe("sandctl-test-project");
+			expect(gcpConfig.credentials_file).toBe("/tmp/gcp-creds.json");
+			expect(gcpConfig.token).toBeUndefined();
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects GCP non-interactive init without project", async () => {
+		await expect(
+			runInit(
+				{
+					provider: "gcp",
+					sshAgent: true,
+				},
+				"/tmp/config.yaml",
+			),
+		).rejects.toThrow("--gcp-project is required in non-interactive mode");
+	});
+
 	test("preserves existing provider config when adding another provider", async () => {
 		const tmpDir = mkdtempSync(path.join(os.tmpdir(), "sandctl-ts-init-"));
 		try {

--- a/tests/unit/gcp/provider.test.ts
+++ b/tests/unit/gcp/provider.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+
+import { type GcpClientLike, GcpProvider } from "@/gcp/provider";
+import { ErrTimeout } from "@/provider/errors";
+
+const TEST_PUBLIC_KEY =
+	"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFV7B8ZLSz6NBI8PrkQ15S9M0W0Hafzz4u9i9Q8fQxXW test@sandctl";
+
+function makeClient(overrides: Partial<GcpClientLike> = {}): GcpClientLike {
+	return {
+		insertInstance: async () => ({ name: "op", status: "DONE" }),
+		getInstance: async (_project, zone, name) => ({
+			id: "123",
+			name,
+			status: "RUNNING",
+			creationTimestamp: "2026-02-20T00:00:00Z",
+			zone: `projects/test/zones/${zone}`,
+			machineType: `projects/test/zones/${zone}/machineTypes/e2-standard-4`,
+			networkInterfaces: [{ accessConfigs: [{ natIP: "203.0.113.10" }] }],
+			disks: [{ boot: true, diskSizeGb: "50" }],
+		}),
+		deleteInstance: async () => ({ name: "op", status: "DONE" }),
+		resetInstance: async () => ({ name: "op", status: "DONE" }),
+		listInstances: async () => [],
+		waitZoneOperation: async () => ({ name: "op", status: "DONE" }),
+		...overrides,
+	};
+}
+
+describe("gcp/provider", () => {
+	test("create sends Compute Engine instance metadata and labels", async () => {
+		let created: Record<string, unknown> | undefined;
+		const client = makeClient({
+			insertInstance: async (opts) => {
+				created = opts.instanceResource;
+				return { name: "insert-op", status: "DONE" };
+			},
+		});
+		const provider = new GcpProvider({ project_id: "test-project" }, client);
+
+		const vm = await provider.create({
+			name: "vm",
+			sshKeyIDs: [TEST_PUBLIC_KEY],
+			userData: "#cloud-config\n",
+		});
+
+		expect(vm.id).toBe("us-central1-a/vm");
+		expect(created?.labels).toEqual({ "managed-by": "sandctl" });
+		expect(created?.machineType).toBe(
+			"zones/us-central1-a/machineTypes/e2-standard-4",
+		);
+		expect(created?.metadata).toEqual({
+			items: [
+				{ key: "ssh-keys", value: `agent:${TEST_PUBLIC_KEY}` },
+				{ key: "user-data", value: "#cloud-config\n" },
+			],
+		});
+	});
+
+	test("ensureSSHKey returns the public key for instance metadata injection", async () => {
+		const provider = new GcpProvider(
+			{ project_id: "test-project" },
+			makeClient(),
+		);
+
+		await expect(
+			provider.ensureSSHKey("sandctl", TEST_PUBLIC_KEY),
+		).resolves.toBe(TEST_PUBLIC_KEY);
+	});
+
+	test("list filters to sandctl-managed instances", async () => {
+		let filter: string | undefined;
+		const client = makeClient({
+			listInstances: async (_project, _zone, requestedFilter) => {
+				filter = requestedFilter;
+				return [
+					{
+						id: "123",
+						name: "vm",
+						status: "RUNNING",
+						creationTimestamp: "2026-02-20T00:00:00Z",
+						machineType:
+							"projects/test/zones/us-central1-a/machineTypes/e2-standard-4",
+					},
+				];
+			},
+		});
+		const provider = new GcpProvider({ project_id: "test-project" }, client);
+
+		const vms = await provider.list();
+
+		expect(filter).toBe("labels.managed-by = sandctl");
+		expect(vms[0].id).toBe("us-central1-a/vm");
+		expect(vms[0].name).toBe("vm");
+	});
+
+	test("delete uses zone/name provider ids for non-default zones", async () => {
+		let deleted: { zone: string; name: string } | undefined;
+		const client = makeClient({
+			deleteInstance: async (_project, zone, name) => {
+				deleted = { zone, name };
+				return { name: "delete-op", status: "DONE" };
+			},
+		});
+		const provider = new GcpProvider({ project_id: "test-project" }, client);
+
+		await provider.delete("us-east1-b/vm");
+
+		expect(deleted).toEqual({ zone: "us-east1-b", name: "vm" });
+	});
+
+	test("waitReady requires SSH to be reachable before succeeding", async () => {
+		const states = [
+			{ status: "PROVISIONING", ip: null },
+			{ status: "RUNNING", ip: null },
+			{ status: "RUNNING", ip: "203.0.113.10" },
+			{ status: "RUNNING", ip: "203.0.113.10" },
+		];
+		let i = 0;
+		let sleepCalls = 0;
+		let probeCalls = 0;
+		let now = 0;
+
+		const client = makeClient({
+			getInstance: async (_project, zone, name) => {
+				const current = states[Math.min(i, states.length - 1)];
+				i += 1;
+				return {
+					id: "123",
+					name,
+					status: current.status,
+					creationTimestamp: "2026-02-20T00:00:00Z",
+					zone: `projects/test/zones/${zone}`,
+					machineType: `projects/test/zones/${zone}/machineTypes/e2-standard-4`,
+					networkInterfaces: current.ip
+						? [{ accessConfigs: [{ natIP: current.ip }] }]
+						: [{ accessConfigs: [] }],
+				};
+			},
+		});
+
+		const provider = new GcpProvider(
+			{ project_id: "test-project" },
+			client,
+			async (ms) => {
+				sleepCalls += 1;
+				now += ms;
+			},
+			async (_host, _port, timeoutMs) => {
+				probeCalls += 1;
+				now += timeoutMs;
+				return probeCalls >= 2;
+			},
+			() => now,
+		);
+
+		await provider.waitReady("vm", 15_000);
+		expect(i).toBe(3);
+		expect(probeCalls).toBe(2);
+		expect(sleepCalls).toBe(3);
+	});
+
+	test("waitReady times out when SSH never becomes reachable", async () => {
+		let probeCalls = 0;
+		let sleepCalls = 0;
+		let now = 0;
+
+		const provider = new GcpProvider(
+			{ project_id: "test-project" },
+			makeClient(),
+			async (ms) => {
+				sleepCalls += 1;
+				now += ms;
+			},
+			async (_host, _port, timeoutMs) => {
+				probeCalls += 1;
+				now += timeoutMs;
+				return false;
+			},
+			() => now,
+		);
+
+		await expect(provider.waitReady("vm", 10_000)).rejects.toBeInstanceOf(
+			ErrTimeout,
+		);
+		expect(probeCalls).toBeGreaterThan(0);
+		expect(sleepCalls).toBeGreaterThan(0);
+	});
+});

--- a/tests/unit/provider/registry.test.ts
+++ b/tests/unit/provider/registry.test.ts
@@ -13,6 +13,7 @@ import {
 describe("provider/registry", () => {
 	test("auto-registers builtin providers on import", () => {
 		expect(available()).toContain("digitalocean");
+		expect(available()).toContain("gcp");
 		expect(available()).toContain("hetzner");
 	});
 
@@ -22,6 +23,7 @@ describe("provider/registry", () => {
 		expect(available().filter((name) => name === "digitalocean")).toHaveLength(
 			1,
 		);
+		expect(available().filter((name) => name === "gcp")).toHaveLength(1);
 		expect(available().filter((name) => name === "hetzner")).toHaveLength(1);
 	});
 
@@ -64,7 +66,7 @@ describe("provider/registry", () => {
 		});
 
 		expect(get("hetzner", config)).toBe(provider);
-		expect(available()).toEqual(["digitalocean", "hetzner"]);
+		expect(available()).toEqual(["digitalocean", "gcp", "hetzner"]);
 	});
 
 	test("get throws typed error for unknown providers", () => {
@@ -115,7 +117,7 @@ describe("provider/registry", () => {
 		register("hetzner", () => {
 			throw new Error("not used");
 		});
-		expect(available()).toEqual(["digitalocean", "hetzner"]);
+		expect(available()).toEqual(["digitalocean", "gcp", "hetzner"]);
 
 		clearRegistry();
 

--- a/tests/unit/provider/sizes.test.ts
+++ b/tests/unit/provider/sizes.test.ts
@@ -25,6 +25,13 @@ describe("provider/sizes", () => {
 		);
 	});
 
+	test("resolves GCP sizes to machine types", () => {
+		expect(resolveSize("small", "gcp")?.serverType).toBe("e2-standard-2");
+		expect(resolveSize("medium", "gcp")?.serverType).toBe("e2-standard-4");
+		expect(resolveSize("large", "gcp")?.serverType).toBe("e2-standard-8");
+		expect(resolveSize("xlarge", "gcp")?.serverType).toBe("e2-standard-16");
+	});
+
 	test("is case-insensitive", () => {
 		expect(resolveSize("Small", "hetzner")?.serverType).toBe("cpx21");
 		expect(resolveSize("LARGE", "digitalocean")?.serverType).toBe(


### PR DESCRIPTION
## Summary
- add a GCP Compute Engine provider using @google-cloud/compute
- wire GCP into init, provider registry, size aliases, config, docs, and env examples
- add unit tests for GCP create/list/delete/wait-ready behavior and GCP init config

## Verification
- npx bun test tests/unit/
- npx bun run lint
- npx bun run build